### PR TITLE
Hono Takibi🔥 App Generetor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ migrations
 dev.db
 dev.db-journal
 cache
-handlers
+pet-store
 .DS_Store

--- a/apps/openapi_hono/src/index.ts
+++ b/apps/openapi_hono/src/index.ts
@@ -37,11 +37,11 @@ api.use('*', async (c, next) => {
 // swagger
 app
   .doc('/doc', {
+    openapi: '3.0.0',
     info: {
       title: 'Hono Sample API',
       version: 'v1',
     },
-    openapi: '3.0.0',
     tags: [
       {
         name: 'Hono',

--- a/packages/hono-takibi/src/config/index.ts
+++ b/packages/hono-takibi/src/config/index.ts
@@ -10,10 +10,10 @@ export type Config = {
     export: boolean
   }
   app?: {
-    output?: string
+    output?: boolean
   }
   handler?: {
-    output?: string
+    output?: boolean
     test?: boolean
   }
   input?: string
@@ -30,10 +30,10 @@ export const DEFAULT_CONFIG: Config = {
     export: false,
   },
   app: {
-    output: 'pet-store/index.ts',
+    output: true,
   },
   handler: {
-    output: 'pet-store/handler',
+    output: true,
     test: true,
   },
 } as const

--- a/packages/hono-takibi/src/config/index.ts
+++ b/packages/hono-takibi/src/config/index.ts
@@ -9,6 +9,9 @@ export type Config = {
     name: 'camelCase' | 'PascalCase'
     export: boolean
   }
+  app?: {
+    output?: string
+  }
   handler?: {
     output?: string
     test?: boolean
@@ -25,6 +28,9 @@ export const DEFAULT_CONFIG: Config = {
   type: {
     name: 'PascalCase',
     export: false,
+  },
+  app: {
+    output: 'index.ts',
   },
   handler: {
     output: 'handlers',

--- a/packages/hono-takibi/src/config/index.ts
+++ b/packages/hono-takibi/src/config/index.ts
@@ -30,11 +30,11 @@ export const DEFAULT_CONFIG: Config = {
     export: false,
   },
   app: {
-    output: true,
+    output: false,
   },
   handler: {
-    output: true,
-    test: true,
+    output: false,
+    test: false,
   },
 } as const
 

--- a/packages/hono-takibi/src/config/index.ts
+++ b/packages/hono-takibi/src/config/index.ts
@@ -30,10 +30,10 @@ export const DEFAULT_CONFIG: Config = {
     export: false,
   },
   app: {
-    output: 'index.ts',
+    output: 'pet-store/index.ts',
   },
   handler: {
-    output: 'handlers',
+    output: 'pet-store/handler',
     test: true,
   },
 } as const

--- a/packages/hono-takibi/src/generators/app/generate-app-route-handler.test.ts
+++ b/packages/hono-takibi/src/generators/app/generate-app-route-handler.test.ts
@@ -28,7 +28,6 @@ describe('generateAppRouteHandler', () => {
     'generateAppRouteHandler($routeName, $handlerName) -> $expected',
     ({ routeName, handlerName, expected }) => {
       const result = generateAppRouteHandler(routeName, handlerName)
-      console.log(result)
       expect(result).toBe(expected)
     },
   )

--- a/packages/hono-takibi/src/generators/app/generate-app-route-handler.test.ts
+++ b/packages/hono-takibi/src/generators/app/generate-app-route-handler.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { generateAppRouteHandler } from './generate-app-route-handler'
+
+const generateAppRouteHandlerTestCases: {
+  routeName: string
+  handlerName: string
+  expected: string
+}[] = [
+  {
+    routeName: 'putPetRoute',
+    handlerName: 'putPetRouteHandler',
+    expected: '.openapi(putPetRoute, putPetRouteHandler)',
+  },
+  {
+    routeName: 'postPetRoute',
+    handlerName: 'postPetRouteHandler',
+    expected: '.openapi(postPetRoute, postPetRouteHandler)',
+  },
+  {
+    routeName: 'getPetFindByStatusRoute',
+    handlerName: 'getPetFindByStatusRouteHandler',
+    expected: '.openapi(getPetFindByStatusRoute, getPetFindByStatusRouteHandler)',
+  },
+]
+
+describe('generateAppRouteHandler', () => {
+  it.concurrent.each(generateAppRouteHandlerTestCases)(
+    'generateAppRouteHandler($routeName, $handlerName) -> $expected',
+    ({ routeName, handlerName, expected }) => {
+      const result = generateAppRouteHandler(routeName, handlerName)
+      console.log(result)
+      expect(result).toBe(expected)
+    },
+  )
+})

--- a/packages/hono-takibi/src/generators/app/generate-app-route-handler.ts
+++ b/packages/hono-takibi/src/generators/app/generate-app-route-handler.ts
@@ -1,0 +1,3 @@
+export function generateAppRouteHandler(routeName: string, handlerName: string) {
+  return `.openapi(${routeName}, ${handlerName})`
+}

--- a/packages/hono-takibi/src/generators/handler/generate-handler-name.test.ts
+++ b/packages/hono-takibi/src/generators/handler/generate-handler-name.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { generateHandlerName } from './generate-handler-name'
+
+const generateHandlerNameTestCases: {
+  method: string
+  path: string
+  expected: string
+}[] = [
+  { method: 'get', path: '/', expected: 'getRouteHandler' },
+  { method: 'post', path: '/posts', expected: 'postPostsRouteHandler' },
+  { method: 'put', path: '/posts/{id}', expected: 'putPostsIdRouteHandler' },
+  { method: 'delete', path: '/posts/{id}', expected: 'deletePostsIdRouteHandler' },
+]
+
+describe('generateHandlerName', () => {
+  it.concurrent.each(generateHandlerNameTestCases)(
+    'generateHandlerName($method, $path) -> $expected',
+    async ({ method, path, expected }) => {
+      const result = generateHandlerName(method, path)
+      expect(result).toBe(expected)
+    },
+  )
+})

--- a/packages/hono-takibi/src/generators/handler/generate-handler-name.ts
+++ b/packages/hono-takibi/src/generators/handler/generate-handler-name.ts
@@ -1,0 +1,5 @@
+import { generateRouteName } from '../openapi/paths/generate-route-name'
+
+export function generateHandlerName(method: string, path: string) {
+  return `${generateRouteName(method, path)}Handler`
+}

--- a/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.test.ts
+++ b/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.test.ts
@@ -35,7 +35,7 @@ const generateImportHandlersTestCases: {
         'deleteUserUsernameRouteHandler',
       ],
     },
-    config: DEFAULT_CONFIG,
+    config: { ...DEFAULT_CONFIG, handler: { output: true } },
     expected: [
       "import { putPetRouteHandler,postPetRouteHandler,getPetFindByStatusRouteHandler,getPetFindByTagsRouteHandler,getPetPetIdRouteHandler,postPetPetIdRouteHandler,deletePetPetIdRouteHandler,postPetPetIdUploadImageRouteHandler } from './handler/pet_handler.ts';",
       "import { getStoreInventoryRouteHandler,postStoreOrderRouteHandler,getStoreOrderOrderIdRouteHandler,deleteStoreOrderOrderIdRouteHandler } from './handler/store_handler.ts';",

--- a/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.test.ts
+++ b/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { generateImportHandlers } from './generate-import-handlers'
+import { DEFAULT_CONFIG, type Config } from '../../../../config'
+
+const generateImportHandlersTestCases: {
+  handlerImportsMap: { [fileName: string]: string[] }
+  config: Config
+  expected: string[]
+}[] = [
+  {
+    handlerImportsMap: {
+      'pet_handler.ts': [
+        'putPetRouteHandler',
+        'postPetRouteHandler',
+        'getPetFindByStatusRouteHandler',
+        'getPetFindByTagsRouteHandler',
+        'getPetPetIdRouteHandler',
+        'postPetPetIdRouteHandler',
+        'deletePetPetIdRouteHandler',
+        'postPetPetIdUploadImageRouteHandler',
+      ],
+      'store_handler.ts': [
+        'getStoreInventoryRouteHandler',
+        'postStoreOrderRouteHandler',
+        'getStoreOrderOrderIdRouteHandler',
+        'deleteStoreOrderOrderIdRouteHandler',
+      ],
+      'user_handler.ts': [
+        'postUserRouteHandler',
+        'postUserCreateWithListRouteHandler',
+        'getUserLoginRouteHandler',
+        'getUserLogoutRouteHandler',
+        'getUserUsernameRouteHandler',
+        'putUserUsernameRouteHandler',
+        'deleteUserUsernameRouteHandler',
+      ],
+    },
+    config: DEFAULT_CONFIG,
+    expected: [
+      "import { putPetRouteHandler,postPetRouteHandler,getPetFindByStatusRouteHandler,getPetFindByTagsRouteHandler,getPetPetIdRouteHandler,postPetPetIdRouteHandler,deletePetPetIdRouteHandler,postPetPetIdUploadImageRouteHandler } from './handlers/pet_handler.ts';",
+      "import { getStoreInventoryRouteHandler,postStoreOrderRouteHandler,getStoreOrderOrderIdRouteHandler,deleteStoreOrderOrderIdRouteHandler } from './handlers/store_handler.ts';",
+      "import { postUserRouteHandler,postUserCreateWithListRouteHandler,getUserLoginRouteHandler,getUserLogoutRouteHandler,getUserUsernameRouteHandler,putUserUsernameRouteHandler,deleteUserUsernameRouteHandler } from './handlers/user_handler.ts';",
+    ],
+  },
+]
+
+describe('generateImportHandlers', () => {
+  it.concurrent.each(generateImportHandlersTestCases)(
+    'generateImportHandlers($handlerImportsMap, $config) -> $expected',
+    ({ handlerImportsMap, config, expected }) => {
+      const result = generateImportHandlers(handlerImportsMap, config)
+      expect(result).toEqual(expected)
+    },
+  )
+})

--- a/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.test.ts
+++ b/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.test.ts
@@ -37,10 +37,10 @@ const generateImportHandlersTestCases: {
     },
     config: DEFAULT_CONFIG,
     expected: [
-      "import { putPetRouteHandler,postPetRouteHandler,getPetFindByStatusRouteHandler,getPetFindByTagsRouteHandler,getPetPetIdRouteHandler,postPetPetIdRouteHandler,deletePetPetIdRouteHandler,postPetPetIdUploadImageRouteHandler } from './handlers/pet_handler.ts';",
-      "import { getStoreInventoryRouteHandler,postStoreOrderRouteHandler,getStoreOrderOrderIdRouteHandler,deleteStoreOrderOrderIdRouteHandler } from './handlers/store_handler.ts';",
-      "import { postUserRouteHandler,postUserCreateWithListRouteHandler,getUserLoginRouteHandler,getUserLogoutRouteHandler,getUserUsernameRouteHandler,putUserUsernameRouteHandler,deleteUserUsernameRouteHandler } from './handlers/user_handler.ts';",
-    ],
+      "import { putPetRouteHandler,postPetRouteHandler,getPetFindByStatusRouteHandler,getPetFindByTagsRouteHandler,getPetPetIdRouteHandler,postPetPetIdRouteHandler,deletePetPetIdRouteHandler,postPetPetIdUploadImageRouteHandler } from './handler/pet_handler.ts';",
+      "import { getStoreInventoryRouteHandler,postStoreOrderRouteHandler,getStoreOrderOrderIdRouteHandler,deleteStoreOrderOrderIdRouteHandler } from './handler/store_handler.ts';",
+      "import { postUserRouteHandler,postUserCreateWithListRouteHandler,getUserLoginRouteHandler,getUserLogoutRouteHandler,getUserUsernameRouteHandler,putUserUsernameRouteHandler,deleteUserUsernameRouteHandler } from './handler/user_handler.ts';"
+    ]
   },
 ]
 

--- a/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.test.ts
+++ b/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.test.ts
@@ -39,8 +39,8 @@ const generateImportHandlersTestCases: {
     expected: [
       "import { putPetRouteHandler,postPetRouteHandler,getPetFindByStatusRouteHandler,getPetFindByTagsRouteHandler,getPetPetIdRouteHandler,postPetPetIdRouteHandler,deletePetPetIdRouteHandler,postPetPetIdUploadImageRouteHandler } from './handler/pet_handler.ts';",
       "import { getStoreInventoryRouteHandler,postStoreOrderRouteHandler,getStoreOrderOrderIdRouteHandler,deleteStoreOrderOrderIdRouteHandler } from './handler/store_handler.ts';",
-      "import { postUserRouteHandler,postUserCreateWithListRouteHandler,getUserLoginRouteHandler,getUserLogoutRouteHandler,getUserUsernameRouteHandler,putUserUsernameRouteHandler,deleteUserUsernameRouteHandler } from './handler/user_handler.ts';"
-    ]
+      "import { postUserRouteHandler,postUserCreateWithListRouteHandler,getUserLoginRouteHandler,getUserLogoutRouteHandler,getUserUsernameRouteHandler,putUserUsernameRouteHandler,deleteUserUsernameRouteHandler } from './handler/user_handler.ts';",
+    ],
   },
 ]
 

--- a/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.ts
+++ b/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.ts
@@ -7,9 +7,13 @@ export function generateImportHandlers(
   const importHandlers: string[] = []
   for (const [fileName, handlers] of Object.entries(handlerImportsMap)) {
     const uniqueHandlers = Array.from(new Set(handlers))
-    importHandlers.push(
-      `import { ${uniqueHandlers.join(',')} } from './${config?.handler?.output}/${fileName}';`,
-    )
+    if (config?.handler?.output === true) {
+      const dirPath = config?.output?.replace(/\/[^/]+\.ts$/, '')
+      const handlerPath = dirPath === 'index.ts' ? 'handler' : `${dirPath}/handler`
+      importHandlers.push(
+        `import { ${uniqueHandlers.join(',')} } from './${handlerPath}/${fileName}';`,
+      )
+    }
   }
   return importHandlers
 }

--- a/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.ts
+++ b/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.ts
@@ -8,10 +8,11 @@ export function generateImportHandlers(
   for (const [fileName, handlers] of Object.entries(handlerImportsMap)) {
     const uniqueHandlers = Array.from(new Set(handlers))
     if (config?.handler?.output === true) {
-      const dirPath = config?.output?.replace(/\/[^/]+\.ts$/, '')
+      const replacePath = config?.output?.replace(/\/[^/]+\.ts$/, '')
+      const dirPath = replacePath === undefined ? '.' : replacePath
       const handlerPath = dirPath === 'index.ts' ? 'handler' : `${dirPath}/handler`
       importHandlers.push(
-        `import { ${uniqueHandlers.join(',')} } from './${handlerPath}/${fileName}';`,
+        `import { ${uniqueHandlers.join(',')} } from '${handlerPath}/${fileName}';`,
       )
     }
   }

--- a/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.ts
+++ b/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.ts
@@ -1,0 +1,15 @@
+import type { Config } from '../../../../config'
+
+export function generateImportHandlers(
+  handlerImportsMap: { [fileName: string]: string[] },
+  config: Config,
+) {
+  const importHandlers: string[] = []
+  for (const [fileName, handlers] of Object.entries(handlerImportsMap)) {
+    const uniqueHandlers = Array.from(new Set(handlers))
+    importHandlers.push(
+      `import { ${uniqueHandlers.join(',')} } from './${config?.handler?.output}/${fileName}';`,
+    )
+  }
+  return importHandlers
+}

--- a/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.ts
+++ b/packages/hono-takibi/src/generators/hono/app/import/generate-import-handlers.ts
@@ -11,9 +11,15 @@ export function generateImportHandlers(
       const replacePath = config?.output?.replace(/\/[^/]+\.ts$/, '')
       const dirPath = replacePath === undefined ? '.' : replacePath
       const handlerPath = dirPath === 'index.ts' ? 'handler' : `${dirPath}/handler`
-      importHandlers.push(
-        `import { ${uniqueHandlers.join(',')} } from '${handlerPath}/${fileName}';`,
-      )
+      if (dirPath === '.') {
+        importHandlers.push(
+          `import { ${uniqueHandlers.join(',')} } from '${handlerPath}/${fileName}';`,
+        )
+      } else {
+        importHandlers.push(
+          `import { ${uniqueHandlers.join(',')} } from './${handlerPath}/${fileName}';`,
+        )
+      }
     }
   }
   return importHandlers

--- a/packages/hono-takibi/src/generators/hono/app/import/get-handler-imports.test.ts
+++ b/packages/hono-takibi/src/generators/hono/app/import/get-handler-imports.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+import { getHandlerImports } from './get-handler-imports'
+
+const getHandlerImportsTestCases: {
+  handlerMaps: {
+    routeName: string
+    handlerName: string
+    path: string
+  }[]
+  expected: { [fileName: string]: string[] }
+}[] = [
+  {
+    handlerMaps: [
+      {
+        routeName: 'putPetRoute',
+        handlerName: 'putPetRouteHandler',
+        path: '/pet',
+      },
+      {
+        routeName: 'postPetRoute',
+        handlerName: 'postPetRouteHandler',
+        path: '/pet',
+      },
+      {
+        routeName: 'getPetFindByStatusRoute',
+        handlerName: 'getPetFindByStatusRouteHandler',
+        path: '/pet/findByStatus',
+      },
+      {
+        routeName: 'getPetFindByTagsRoute',
+        handlerName: 'getPetFindByTagsRouteHandler',
+        path: '/pet/findByTags',
+      },
+      {
+        routeName: 'getPetPetIdRoute',
+        handlerName: 'getPetPetIdRouteHandler',
+        path: '/pet/{petId}',
+      },
+      {
+        routeName: 'postPetPetIdRoute',
+        handlerName: 'postPetPetIdRouteHandler',
+        path: '/pet/{petId}',
+      },
+      {
+        routeName: 'deletePetPetIdRoute',
+        handlerName: 'deletePetPetIdRouteHandler',
+        path: '/pet/{petId}',
+      },
+      {
+        routeName: 'postPetPetIdUploadImageRoute',
+        handlerName: 'postPetPetIdUploadImageRouteHandler',
+        path: '/pet/{petId}/uploadImage',
+      },
+      {
+        routeName: 'getStoreInventoryRoute',
+        handlerName: 'getStoreInventoryRouteHandler',
+        path: '/store/inventory',
+      },
+      {
+        routeName: 'postStoreOrderRoute',
+        handlerName: 'postStoreOrderRouteHandler',
+        path: '/store/order',
+      },
+      {
+        routeName: 'getStoreOrderOrderIdRoute',
+        handlerName: 'getStoreOrderOrderIdRouteHandler',
+        path: '/store/order/{orderId}',
+      },
+      {
+        routeName: 'deleteStoreOrderOrderIdRoute',
+        handlerName: 'deleteStoreOrderOrderIdRouteHandler',
+        path: '/store/order/{orderId}',
+      },
+      {
+        routeName: 'postUserRoute',
+        handlerName: 'postUserRouteHandler',
+        path: '/user',
+      },
+      {
+        routeName: 'postUserCreateWithListRoute',
+        handlerName: 'postUserCreateWithListRouteHandler',
+        path: '/user/createWithList',
+      },
+      {
+        routeName: 'getUserLoginRoute',
+        handlerName: 'getUserLoginRouteHandler',
+        path: '/user/login',
+      },
+      {
+        routeName: 'getUserLogoutRoute',
+        handlerName: 'getUserLogoutRouteHandler',
+        path: '/user/logout',
+      },
+      {
+        routeName: 'getUserUsernameRoute',
+        handlerName: 'getUserUsernameRouteHandler',
+        path: '/user/{username}',
+      },
+      {
+        routeName: 'putUserUsernameRoute',
+        handlerName: 'putUserUsernameRouteHandler',
+        path: '/user/{username}',
+      },
+      {
+        routeName: 'deleteUserUsernameRoute',
+        handlerName: 'deleteUserUsernameRouteHandler',
+        path: '/user/{username}',
+      },
+    ],
+    expected: {
+      'pet_handler.ts': [
+        'putPetRouteHandler',
+        'postPetRouteHandler',
+        'getPetFindByStatusRouteHandler',
+        'getPetFindByTagsRouteHandler',
+        'getPetPetIdRouteHandler',
+        'postPetPetIdRouteHandler',
+        'deletePetPetIdRouteHandler',
+        'postPetPetIdUploadImageRouteHandler',
+      ],
+      'store_handler.ts': [
+        'getStoreInventoryRouteHandler',
+        'postStoreOrderRouteHandler',
+        'getStoreOrderOrderIdRouteHandler',
+        'deleteStoreOrderOrderIdRouteHandler',
+      ],
+      'user_handler.ts': [
+        'postUserRouteHandler',
+        'postUserCreateWithListRouteHandler',
+        'getUserLoginRouteHandler',
+        'getUserLogoutRouteHandler',
+        'getUserUsernameRouteHandler',
+        'putUserUsernameRouteHandler',
+        'deleteUserUsernameRouteHandler',
+      ],
+    },
+  },
+]
+
+describe('getHandlerImports', () => {
+  it.concurrent.each(getHandlerImportsTestCases)(
+    'getHandlerImports($handlerMaps) -> $expected',
+    ({ handlerMaps, expected }) => {
+      const result = getHandlerImports(handlerMaps)
+      expect(result).toEqual(expected)
+    },
+  )
+})

--- a/packages/hono-takibi/src/generators/hono/app/import/get-handler-imports.ts
+++ b/packages/hono-takibi/src/generators/hono/app/import/get-handler-imports.ts
@@ -1,0 +1,23 @@
+export function getHandlerImports(
+  handlerMaps: {
+    routeName: string
+    handlerName: string
+    path: string
+  }[],
+) {
+  const getHandlerImports: { [fileName: string]: string[] } = {}
+  for (const { handlerName, path } of handlerMaps) {
+    const path_name = path
+      .replace(/[\/{}-]/g, ' ')
+      .trim()
+      .split(/\s+/)[0]
+
+    const fileName = path_name.length === 0 ? 'index_handler.ts' : `${path_name}_handler.ts`
+
+    if (!getHandlerImports[fileName]) {
+      getHandlerImports[fileName] = []
+    }
+    getHandlerImports[fileName].push(handlerName)
+  }
+  return getHandlerImports
+}

--- a/packages/hono-takibi/src/generators/hono/app/import/get-route-maps.test.ts
+++ b/packages/hono-takibi/src/generators/hono/app/import/get-route-maps.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { getRouteMaps } from './get-route-maps'
+import type { OpenAPISpec } from '../../../../types'
+import { honoRestOpenAPI } from '../../../../data/hono-rest-openapi'
+
+const getRouteMapsTestCases: {
+  openAPISpec: OpenAPISpec
+  expected: { routeName: string; handlerName: string; path: string }[]
+}[] = [
+  {
+    openAPISpec: honoRestOpenAPI,
+    expected: [
+      { routeName: 'getRoute', handlerName: 'getRouteHandler', path: '/' },
+      {
+        routeName: 'postPostsRoute',
+        handlerName: 'postPostsRouteHandler',
+        path: '/posts',
+      },
+      {
+        routeName: 'getPostsRoute',
+        handlerName: 'getPostsRouteHandler',
+        path: '/posts',
+      },
+      {
+        routeName: 'putPostsIdRoute',
+        handlerName: 'putPostsIdRouteHandler',
+        path: '/posts/{id}',
+      },
+      {
+        routeName: 'deletePostsIdRoute',
+        handlerName: 'deletePostsIdRouteHandler',
+        path: '/posts/{id}',
+      },
+    ],
+  },
+]
+
+describe('getRouteMaps', () => {
+  it.concurrent.each(getRouteMapsTestCases)(
+    'getRouteMaps($openAPISpec) -> $expected',
+    ({ openAPISpec, expected }) => {
+      const result = getRouteMaps(openAPISpec)
+      expect(result).toEqual(expected)
+    },
+  )
+})

--- a/packages/hono-takibi/src/generators/hono/app/import/get-route-maps.ts
+++ b/packages/hono-takibi/src/generators/hono/app/import/get-route-maps.ts
@@ -1,0 +1,15 @@
+import type { OpenAPISpec } from '../../../../types'
+import { generateHandlerName } from '../../../handler/generate-handler-name'
+import { generateRouteName } from '../../../openapi/paths/generate-route-name'
+
+export function getRouteMaps(openAPISpec: OpenAPISpec) {
+  const paths = openAPISpec.paths
+  const routeMappings = Object.entries(paths).flatMap(([path, pathItem]) => {
+    return Object.entries(pathItem).flatMap(([method]) => {
+      const routeName = generateRouteName(method, path)
+      const handlerName = generateHandlerName(method, path)
+      return { routeName, handlerName, path }
+    })
+  })
+  return routeMappings
+}

--- a/packages/hono-takibi/src/generators/hono/app/index.ts
+++ b/packages/hono-takibi/src/generators/hono/app/index.ts
@@ -17,8 +17,6 @@ export function generateApp(openAPISpec: OpenAPISpec, config: Config) {
 
   for (const { routeName } of routeMappings) {
     const importPath = config.output
-
-    console.log(importPath)
     if (!importPath) {
       throw new Error('Output path is required')
     }
@@ -35,6 +33,8 @@ export function generateApp(openAPISpec: OpenAPISpec, config: Config) {
       const normalizedPath = importPath.replace(/\/index\.ts$/, '')
       importRoutes.push(`import { ${uniqueNames.join(', ')} } from './${normalizedPath}';`)
     } else {
+      // const isIndexTs = importPath === 'index.ts'
+      // importRoutes.push(`import { ${uniqueNames.join(',')} } from './${isIndexTs ? '' : importPath}';`)
       importRoutes.push(`import { ${uniqueNames.join(',')} } from './${importPath}';`)
     }
   }

--- a/packages/hono-takibi/src/generators/hono/app/index.ts
+++ b/packages/hono-takibi/src/generators/hono/app/index.ts
@@ -1,0 +1,57 @@
+import type { OpenAPISpec } from '../../../types'
+import type { Config } from '../../../config'
+import { generateAppRouteHandler } from '../../app/generate-app-route-handler'
+import { generateDocs } from '../../openapi/docs/generate-docs'
+import { getHandlerImports } from './import/get-handler-imports'
+import { getRouteMaps } from './import/get-route-maps'
+import { generateImportHandlers } from './import/generate-import-handlers'
+
+const OPENAPI_HONO_IMPORT = `import { OpenAPIHono } from '@hono/zod-openapi'` as const
+const SWAGGER_UI_IMPORT = `import { swaggerUI } from '@hono/swagger-ui'` as const
+const APP = 'const app = new OpenAPIHono()' as const
+
+export function generateApp(openAPISpec: OpenAPISpec, config: Config) {
+  const routeMappings = getRouteMaps(openAPISpec)
+
+  const importsMap: { [importPath: string]: string[] } = {}
+
+  for (const { routeName } of routeMappings) {
+    const importPath = config.output
+    if (!importPath) {
+      throw new Error('Output path is required')
+    }
+    if (!importsMap[importPath]) {
+      importsMap[importPath] = []
+    }
+    importsMap[importPath].push(routeName)
+  }
+
+  const importRoutes: string[] = []
+  for (const [importPath, names] of Object.entries(importsMap)) {
+    const uniqueNames = Array.from(new Set(names))
+    importRoutes.push(`import { ${uniqueNames.join(',')} } from './${importPath}';`)
+  }
+
+  const handlerImportsMap: { [fileName: string]: string[] } = getHandlerImports(routeMappings)
+
+  const importHandlers = generateImportHandlers(handlerImportsMap, config)
+
+  const importHandlersCode = importHandlers.join('\n')
+
+  const openapiRoutes = routeMappings
+    .map(({ routeName, handlerName }) => {
+      return generateAppRouteHandler(routeName, handlerName)
+    })
+    .join('\n')
+
+  const api = `app${openapiRoutes}`
+
+  const docs = generateDocs(openAPISpec)
+
+  const basePath = 'api'
+  const swagger = `app.doc('${'/doc'}',${JSON.stringify(docs)}).get('/ui', swaggerUI({ url: '${basePath}/doc' }))`
+
+  const appCode = `${OPENAPI_HONO_IMPORT}\n${SWAGGER_UI_IMPORT}\n${importRoutes.join('\n')}\n${importHandlersCode}\n\n${APP}\n\n${api}\n\n${swagger}`
+
+  return appCode
+}

--- a/packages/hono-takibi/src/generators/hono/app/index.ts
+++ b/packages/hono-takibi/src/generators/hono/app/index.ts
@@ -17,6 +17,8 @@ export function generateApp(openAPISpec: OpenAPISpec, config: Config) {
 
   for (const { routeName } of routeMappings) {
     const importPath = config.output
+
+    console.log(importPath)
     if (!importPath) {
       throw new Error('Output path is required')
     }
@@ -29,7 +31,12 @@ export function generateApp(openAPISpec: OpenAPISpec, config: Config) {
   const importRoutes: string[] = []
   for (const [importPath, names] of Object.entries(importsMap)) {
     const uniqueNames = Array.from(new Set(names))
-    importRoutes.push(`import { ${uniqueNames.join(',')} } from './${importPath}';`)
+    if (importPath.includes('/index.ts')) {
+      const normalizedPath = importPath.replace(/\/index\.ts$/, '')
+      importRoutes.push(`import { ${uniqueNames.join(', ')} } from './${normalizedPath}';`)
+    } else {
+      importRoutes.push(`import { ${uniqueNames.join(',')} } from './${importPath}';`)
+    }
   }
 
   const handlerImportsMap: { [fileName: string]: string[] } = getHandlerImports(routeMappings)

--- a/packages/hono-takibi/src/generators/hono/app/index.ts
+++ b/packages/hono-takibi/src/generators/hono/app/index.ts
@@ -31,7 +31,7 @@ export function generateApp(openAPISpec: OpenAPISpec, config: Config) {
     const uniqueNames = Array.from(new Set(names))
     if (importPath.includes('/index.ts')) {
       const normalizedPath = importPath.replace(/\/index\.ts$/, '')
-      importRoutes.push(`import { ${uniqueNames.join(', ')} } from './${normalizedPath}';`)
+      importRoutes.push(`import { ${uniqueNames.join(',')} } from './${normalizedPath}';`)
     } else {
       // const isIndexTs = importPath === 'index.ts'
       // importRoutes.push(`import { ${uniqueNames.join(',')} } from './${isIndexTs ? '' : importPath}';`)

--- a/packages/hono-takibi/src/generators/hono/generate-zod-openapi-hono.ts
+++ b/packages/hono-takibi/src/generators/hono/generate-zod-openapi-hono.ts
@@ -21,7 +21,7 @@ export function generateZodOpenAPIHono(openAPISpec: OpenAPISpec, config: Config)
   // 1. get components
   const components = openAPISpec.components ? openAPISpec.components : undefined
   if (!components) {
-    throw new Error('Components are required')
+    throw new Error(`Cannot destructure property 'schemas' of 'components' as it is undefined.`)
   }
   // 2. get paths
   const { paths } = openAPISpec

--- a/packages/hono-takibi/src/generators/hono/generate-zod-openapi-hono.ts
+++ b/packages/hono-takibi/src/generators/hono/generate-zod-openapi-hono.ts
@@ -19,7 +19,10 @@ const IMPORT_CODE = "import { createRoute, z } from '@hono/zod-openapi';" as con
  */
 export function generateZodOpenAPIHono(openAPISpec: OpenAPISpec, config: Config): string {
   // 1. get components
-  const components = openAPISpec.components
+  const components = openAPISpec.components ? openAPISpec.components : undefined
+  if (!components) {
+    throw new Error('Components are required')
+  }
   // 2. get paths
   const { paths } = openAPISpec
   // 3. generate components code

--- a/packages/hono-takibi/src/generators/hono/handler/generate-zod-openapi-hono-handler.ts
+++ b/packages/hono-takibi/src/generators/hono/handler/generate-zod-openapi-hono-handler.ts
@@ -5,6 +5,7 @@ import { generateRouteName } from '../../openapi/paths/generate-route-name'
 import type { Config } from '../../../config'
 import { groupHandlersByFileNameHelper } from './helper/group-handlers-by-file-name-helper'
 import { formatCode } from '../../../format'
+import { generateHandlerName } from '../../handler/generate-handler-name'
 
 const ROUTE_HANDLER = `import type { RouteHandler } from '@hono/zod-openapi'` as const
 
@@ -21,7 +22,7 @@ export async function generateZodOpenapiHonoHandler(openapi: OpenAPISpec, config
   for (const [path, pathItem] of Object.entries(paths)) {
     for (const [method] of Object.entries(pathItem)) {
       const routeName = generateRouteName(method, path)
-      const handlerName = `${generateRouteName(method, path)}Handler`
+      const handlerName = generateHandlerName(method, path)
 
       const routeHandlerContent = generateHandler(handlerName, routeName)
 

--- a/packages/hono-takibi/src/generators/hono/handler/generate-zod-openapi-hono-handler.ts
+++ b/packages/hono-takibi/src/generators/hono/handler/generate-zod-openapi-hono-handler.ts
@@ -58,8 +58,12 @@ export async function generateZodOpenapiHonoHandler(openapi: OpenAPISpec, config
 
       const routeTypes = handler.routeNames.map((routeName) => `${routeName}`).join(', ')
 
+      const match = config.output?.match(/[^/]+\.ts$/)
+
+      const matchPath = match ? match[0] : ''
+
       const path =
-        config.output === '.' || config.output === './' ? 'config.output' : `../${config.output}`
+        config.output === '.' || config.output === './' ? config.output : `../${matchPath}`
 
       const importRouteTypes = routeTypes ? `import type { ${routeTypes} } from '${path}';` : ''
 

--- a/packages/hono-takibi/src/generators/openapi/docs/generate-docs.test.ts
+++ b/packages/hono-takibi/src/generators/openapi/docs/generate-docs.test.ts
@@ -44,4 +44,3 @@ describe('generateDocs', () => {
     },
   )
 })
-

--- a/packages/hono-takibi/src/generators/openapi/docs/generate-docs.test.ts
+++ b/packages/hono-takibi/src/generators/openapi/docs/generate-docs.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { OpenAPISpec } from '../../../types'
+import { petStoreOpenAPI } from '../../../data/pet-store-openapi'
+import { honoRestOpenAPI } from '../../../data/hono-rest-openapi'
+import { generateDocs } from './generate-docs'
+
+const generateDocsTestCases: {
+  openAPISpec: OpenAPISpec
+  expected: {
+    openapi: string
+    info: OpenAPISpec['info']
+    servers?: OpenAPISpec['servers']
+    externalDocs: OpenAPISpec['externalDocs']
+    tags: OpenAPISpec['tags']
+  }
+}[] = [
+  {
+    openAPISpec: honoRestOpenAPI,
+    expected: {
+      openapi: '3.1.0',
+      info: { title: 'Hono API', version: 'v1' },
+      servers: undefined,
+      externalDocs: undefined,
+      tags: [
+        {
+          name: 'Hono',
+          description: 'Endpoints related to general Hono operations',
+        },
+        {
+          name: 'Post',
+          description: 'Endpoints for creating, retrieving, updating, and deleting posts',
+        },
+      ],
+    },
+  },
+]
+
+describe('generateDocs', () => {
+  it.concurrent.each(generateDocsTestCases)(
+    'generateDocs($openAPISpec) -> $expected',
+    ({ openAPISpec, expected }) => {
+      const result = generateDocs(openAPISpec)
+      expect(result).toEqual(expected)
+    },
+  )
+})
+

--- a/packages/hono-takibi/src/generators/openapi/docs/generate-docs.ts
+++ b/packages/hono-takibi/src/generators/openapi/docs/generate-docs.ts
@@ -1,0 +1,17 @@
+import type { OpenAPISpec } from '../../../types'
+
+export function generateDocs(openAPISpec: OpenAPISpec): {
+  openapi: string
+  info: OpenAPISpec['info']
+  servers: OpenAPISpec['servers']
+  externalDocs: OpenAPISpec['externalDocs']
+  tags: OpenAPISpec['tags']
+} {
+  return {
+    openapi: openAPISpec.openapi,
+    info: openAPISpec.info,
+    servers: openAPISpec.servers,
+    externalDocs: openAPISpec.externalDocs,
+    tags: openAPISpec.tags,
+  }
+}

--- a/packages/hono-takibi/src/generators/openapi/docs/generate-docs.ts
+++ b/packages/hono-takibi/src/generators/openapi/docs/generate-docs.ts
@@ -1,7 +1,7 @@
 import type { OpenAPISpec } from '../../../types'
 
 export function generateDocs(openAPISpec: OpenAPISpec): {
-  openapi: string
+  openapi: string | undefined
   info: OpenAPISpec['info']
   servers: OpenAPISpec['servers']
   externalDocs: OpenAPISpec['externalDocs']

--- a/packages/hono-takibi/src/index.ts
+++ b/packages/hono-takibi/src/index.ts
@@ -70,7 +70,7 @@ export async function main(dev = false, config: Config = getConfig()) {
       const formattedAppCode = await formatCode(appCode)
       if (config.app.output === true) {
         const defaultFileName = 'index.ts'
-        const alternativeFileName = 'app.ts'
+        const alternativeFileName = 'main.ts'
         const outputFile = fs.existsSync(defaultFileName) ? alternativeFileName : defaultFileName
 
         fs.writeFileSync(outputFile, formattedAppCode, { encoding: 'utf-8' })

--- a/packages/hono-takibi/src/index.ts
+++ b/packages/hono-takibi/src/index.ts
@@ -3,13 +3,13 @@
 import SwaggerParser from '@apidevtools/swagger-parser'
 import fs from 'node:fs'
 import path from 'node:path'
-import { format } from 'prettier'
 import { generateZodOpenAPIHono } from './generators/hono/generate-zod-openapi-hono'
 import { generateZodOpenapiHonoHandler } from './generators/hono/handler/generate-zod-openapi-hono-handler'
 import type { OpenAPISpec } from './types'
 import type { Config } from './config'
 import { getConfig } from './config'
 import { formatCode } from './format'
+import { generateApp } from './generators/hono/app'
 
 /**
  * CLI entry point for hono-takibi
@@ -63,6 +63,14 @@ export async function main(dev = false, config: Config = getConfig()) {
     if (config.handler) {
       await generateZodOpenapiHonoHandler(openAPI, config)
     }
+
+    // 11. generate app code
+    const appCode = generateApp(openAPI, config)
+    if (config.app?.output) {
+      const formattedAppCode = await formatCode(appCode)
+      fs.writeFileSync(config.app.output, formattedAppCode, { encoding: 'utf-8' })
+    }
+
     console.log(`Generated code written to ${output}`)
     return true
   } catch (e) {

--- a/packages/hono-takibi/src/index.ts
+++ b/packages/hono-takibi/src/index.ts
@@ -68,7 +68,14 @@ export async function main(dev = false, config: Config = getConfig()) {
     const appCode = generateApp(openAPI, config)
     if (config.app?.output) {
       const formattedAppCode = await formatCode(appCode)
-      fs.writeFileSync(config.app.output, formattedAppCode, { encoding: 'utf-8' })
+      if (config.app.output === true) {
+        const defaultFileName = 'index.ts'
+        const alternativeFileName = 'app.ts'
+        const outputFile = fs.existsSync(defaultFileName) ? alternativeFileName : defaultFileName
+
+        fs.writeFileSync(outputFile, formattedAppCode, { encoding: 'utf-8' })
+      }
+      // fs.writeFileSync(config.app.output, formattedAppCode, { encoding: 'utf-8' })
     }
 
     console.log(`Generated code written to ${output}`)

--- a/packages/hono-takibi/src/types/index.ts
+++ b/packages/hono-takibi/src/types/index.ts
@@ -9,9 +9,9 @@ export type OpenAPI = Awaited<ReturnType<typeof SwaggerParser.parse>>
  * Extended OpenAPI specification with required components and paths
  */
 export type OpenAPISpec = OpenAPI & {
-  openapi: string
-  servers: string
-  components: Components
+  openapi?: string
+  servers?: string
+  components?: Components
 } & {
   paths: OpenAPIPaths
 }

--- a/packages/hono-takibi/src/types/index.ts
+++ b/packages/hono-takibi/src/types/index.ts
@@ -11,7 +11,7 @@ export type OpenAPI = Awaited<ReturnType<typeof SwaggerParser.parse>>
 export type OpenAPISpec = OpenAPI & {
   openapi?: string
   servers?: string
-  components?: Components
+  components: Components
 } & {
   paths: OpenAPIPaths
 }

--- a/packages/hono-takibi/src/types/index.ts
+++ b/packages/hono-takibi/src/types/index.ts
@@ -9,6 +9,8 @@ export type OpenAPI = Awaited<ReturnType<typeof SwaggerParser.parse>>
  * Extended OpenAPI specification with required components and paths
  */
 export type OpenAPISpec = OpenAPI & {
+  openapi: string
+  servers: string
   components: Components
 } & {
   paths: OpenAPIPaths

--- a/packages/hono-takibi/vitest.config.ts
+++ b/packages/hono-takibi/vitest.config.ts
@@ -2,8 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    // include: ['**/src/**/*.test.ts'],
-    include: ['**/src/**/generate-import-handlers.test.ts'],
+    include: ['**/src/**/*.test.ts'],
     exclude: ['**/node_modules'],
     coverage: {
       include: ['**/src/**/*.test.ts'],

--- a/packages/hono-takibi/vitest.config.ts
+++ b/packages/hono-takibi/vitest.config.ts
@@ -2,7 +2,8 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['**/src/**/*.test.ts'],
+    // include: ['**/src/**/*.test.ts'],
+    include: ['**/src/**/generate-import-handlers.test.ts'],
     exclude: ['**/node_modules'],
     coverage: {
       include: ['**/src/**/*.test.ts'],


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests

### Generate App Code

```ts
import { OpenAPIHono } from '@hono/zod-openapi'
import { swaggerUI } from '@hono/swagger-ui'
import {
  putPetRoute,
  postPetRoute,
  getPetFindByStatusRoute,
  getPetFindByTagsRoute,
  getPetPetIdRoute,
  postPetPetIdRoute,
  deletePetPetIdRoute,
  postPetPetIdUploadImageRoute,
  getStoreInventoryRoute,
  postStoreOrderRoute,
  getStoreOrderOrderIdRoute,
  deleteStoreOrderOrderIdRoute,
  postUserRoute,
  postUserCreateWithListRoute,
  getUserLoginRoute,
  getUserLogoutRoute,
  getUserUsernameRoute,
  putUserUsernameRoute,
  deleteUserUsernameRoute,
} from './index.ts'
import {
  putPetRouteHandler,
  postPetRouteHandler,
  getPetFindByStatusRouteHandler,
  getPetFindByTagsRouteHandler,
  getPetPetIdRouteHandler,
  postPetPetIdRouteHandler,
  deletePetPetIdRouteHandler,
  postPetPetIdUploadImageRouteHandler,
} from './handler/pet_handler.ts'
import {
  getStoreInventoryRouteHandler,
  postStoreOrderRouteHandler,
  getStoreOrderOrderIdRouteHandler,
  deleteStoreOrderOrderIdRouteHandler,
} from './handler/store_handler.ts'
import {
  postUserRouteHandler,
  postUserCreateWithListRouteHandler,
  getUserLoginRouteHandler,
  getUserLogoutRouteHandler,
  getUserUsernameRouteHandler,
  putUserUsernameRouteHandler,
  deleteUserUsernameRouteHandler,
} from './handler/user_handler.ts'

const app = new OpenAPIHono()

app
  .openapi(putPetRoute, putPetRouteHandler)
  .openapi(postPetRoute, postPetRouteHandler)
  .openapi(getPetFindByStatusRoute, getPetFindByStatusRouteHandler)
  .openapi(getPetFindByTagsRoute, getPetFindByTagsRouteHandler)
  .openapi(getPetPetIdRoute, getPetPetIdRouteHandler)
  .openapi(postPetPetIdRoute, postPetPetIdRouteHandler)
  .openapi(deletePetPetIdRoute, deletePetPetIdRouteHandler)
  .openapi(postPetPetIdUploadImageRoute, postPetPetIdUploadImageRouteHandler)
  .openapi(getStoreInventoryRoute, getStoreInventoryRouteHandler)
  .openapi(postStoreOrderRoute, postStoreOrderRouteHandler)
  .openapi(getStoreOrderOrderIdRoute, getStoreOrderOrderIdRouteHandler)
  .openapi(deleteStoreOrderOrderIdRoute, deleteStoreOrderOrderIdRouteHandler)
  .openapi(postUserRoute, postUserRouteHandler)
  .openapi(postUserCreateWithListRoute, postUserCreateWithListRouteHandler)
  .openapi(getUserLoginRoute, getUserLoginRouteHandler)
  .openapi(getUserLogoutRoute, getUserLogoutRouteHandler)
  .openapi(getUserUsernameRoute, getUserUsernameRouteHandler)
  .openapi(putUserUsernameRoute, putUserUsernameRouteHandler)
  .openapi(deleteUserUsernameRoute, deleteUserUsernameRouteHandler)
```