### PR TITLE
0.1.0

### DIFF
--- a/packages/hono-takibi/package.json
+++ b/packages/hono-takibi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono-takibi",
-  "version": "0.9.99999",
+  "version": "0.1.0",
   "description": "Hono Takibi is a code generator from OpenAPI to @hono/zod-openapi",
   "keywords": [
     "hono",

--- a/packages/hono-takibi/src/core/hooks/index.test.ts
+++ b/packages/hono-takibi/src/core/hooks/index.test.ts
@@ -1988,10 +1988,13 @@ export function useHono<
   TData = Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
   TError = unknown,
 >(options?: {
-  query?: UseQueryOptions<
-    Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-    TError,
-    TData
+  query?: Omit<
+    UseQueryOptions<
+      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+      TError,
+      TData
+    >,
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -2011,10 +2014,13 @@ export function useSuspenseHono<
   TData = Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
   TError = unknown,
 >(options?: {
-  query?: UseSuspenseQueryOptions<
-    Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-    TError,
-    TData
+  query?: Omit<
+    UseSuspenseQueryOptions<
+      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+      TError,
+      TData
+    >,
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -2091,12 +2097,15 @@ export function useInfiniteHono<
     getRequestArgs: (pageParam: unknown) => InferRequestType<typeof client.hono.$get>
   },
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getHonoInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getHonoInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -2143,12 +2152,15 @@ export function useSuspenseInfiniteHono<
     getRequestArgs: (pageParam: unknown) => InferRequestType<typeof client.hono.$get>
   },
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getHonoInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getHonoInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -2197,10 +2209,13 @@ export function useUsers<
 >(
   args: InferRequestType<typeof client.users.$get>,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -2223,10 +2238,13 @@ export function useSuspenseUsers<
 >(
   args: InferRequestType<typeof client.users.$get>,
   options?: {
-    query?: UseSuspenseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -2312,12 +2330,15 @@ export function useInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -2368,12 +2389,15 @@ export function useSuspenseInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -2500,10 +2524,13 @@ export function useHono<
   TData = Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
   TError = unknown,
 >(options?: {
-  query?: UseQueryOptions<
-    Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-    TError,
-    TData
+  query?: Omit<
+    UseQueryOptions<
+      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+      TError,
+      TData
+    >,
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -2523,10 +2550,13 @@ export function useSuspenseHono<
   TData = Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
   TError = unknown,
 >(options?: {
-  query?: UseSuspenseQueryOptions<
-    Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-    TError,
-    TData
+  query?: Omit<
+    UseSuspenseQueryOptions<
+      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+      TError,
+      TData
+    >,
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -2603,12 +2633,15 @@ export function useInfiniteHono<
     getRequestArgs: (pageParam: unknown) => InferRequestType<typeof client.hono.$get>
   },
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getHonoInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getHonoInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -2655,12 +2688,15 @@ export function useSuspenseInfiniteHono<
     getRequestArgs: (pageParam: unknown) => InferRequestType<typeof client.hono.$get>
   },
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getHonoInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getHonoInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -2733,10 +2769,13 @@ export function useUsers<
 >(
   args: InferRequestType<typeof client.users.$get>,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -2759,10 +2798,13 @@ export function useSuspenseUsers<
 >(
   args: InferRequestType<typeof client.users.$get>,
   options?: {
-    query?: UseSuspenseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -2848,12 +2890,15 @@ export function useInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -2904,12 +2949,15 @@ export function useSuspenseInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -3059,10 +3107,13 @@ export function useUsers<
   >,
   TError = unknown,
 >(options?: {
-  query?: UseQueryOptions<
-    Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>>,
-    TError,
-    TData
+  query?: Omit<
+    UseQueryOptions<
+      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>>,
+      TError,
+      TData
+    >,
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -3087,10 +3138,13 @@ export function useSuspenseUsers<
   >,
   TError = unknown,
 >(options?: {
-  query?: UseSuspenseQueryOptions<
-    Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>>,
-    TError,
-    TData
+  query?: Omit<
+    UseSuspenseQueryOptions<
+      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>>,
+      TError,
+      TData
+    >,
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -3170,12 +3224,17 @@ export function useInfiniteUsers<
     getRequestArgs: (pageParam: unknown) => InferRequestType<typeof authClient.users.$get>
   },
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseInfiniteQueryOptions<
+        Awaited<
+          ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>
+        >,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -3222,12 +3281,17 @@ export function useSuspenseInfiniteUsers<
     getRequestArgs: (pageParam: unknown) => InferRequestType<typeof authClient.users.$get>
   },
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<
+          ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>
+        >,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -3336,10 +3400,13 @@ export function usePing<
   TData = Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
   TError = unknown,
 >(options?: {
-  query?: UseQueryOptions<
-    Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
-    TError,
-    TData
+  query?: Omit<
+    UseQueryOptions<
+      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
+      TError,
+      TData
+    >,
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -3359,10 +3426,13 @@ export function useSuspensePing<
   TData = Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
   TError = unknown,
 >(options?: {
-  query?: UseSuspenseQueryOptions<
-    Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
-    TError,
-    TData
+  query?: Omit<
+    UseSuspenseQueryOptions<
+      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
+      TError,
+      TData
+    >,
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -3439,12 +3509,15 @@ export function useInfinitePing<
     getRequestArgs: (pageParam: unknown) => InferRequestType<typeof client.ping.$get>
   },
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getPingInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getPingInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -3491,12 +3564,15 @@ export function useSuspenseInfinitePing<
     getRequestArgs: (pageParam: unknown) => InferRequestType<typeof client.ping.$get>
   },
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getPingInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getPingInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -3631,12 +3707,15 @@ export function useHonoX<
   >,
   TError = unknown,
 >(options?: {
-  query?: UseQueryOptions<
-    Awaited<
-      ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+  query?: Omit<
+    UseQueryOptions<
+      Awaited<
+        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+      >,
+      TError,
+      TData
     >,
-    TError,
-    TData
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -3661,12 +3740,15 @@ export function useSuspenseHonoX<
   >,
   TError = unknown,
 >(options?: {
-  query?: UseSuspenseQueryOptions<
-    Awaited<
-      ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+  query?: Omit<
+    UseSuspenseQueryOptions<
+      Awaited<
+        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+      >,
+      TError,
+      TData
     >,
-    TError,
-    TData
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -3748,14 +3830,17 @@ export function useInfiniteHonoX<
     getRequestArgs: (pageParam: unknown) => InferRequestType<(typeof client)['hono-x']['$get']>
   },
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+    query?: Omit<
+      UseInfiniteQueryOptions<
+        Awaited<
+          ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+        >,
+        TError,
+        TData,
+        ReturnType<typeof getHonoXInfiniteQueryKey>,
+        TPageParam
       >,
-      TError,
-      TData,
-      ReturnType<typeof getHonoXInfiniteQueryKey>,
-      TPageParam
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -3804,14 +3889,17 @@ export function useSuspenseInfiniteHonoX<
     getRequestArgs: (pageParam: unknown) => InferRequestType<(typeof client)['hono-x']['$get']>
   },
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+    query?: Omit<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<
+          ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+        >,
+        TError,
+        TData,
+        ReturnType<typeof getHonoXInfiniteQueryKey>,
+        TPageParam
       >,
-      TError,
-      TData,
-      ReturnType<typeof getHonoXInfiniteQueryKey>,
-      TPageParam
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -3932,12 +4020,17 @@ export function useUsersId<
 >(
   args: InferRequestType<(typeof client.users)[':id']['$get']>,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query?: Omit<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+          >
+        >,
+        TError,
+        TData
       >,
-      TError,
-      TData
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -3965,12 +4058,17 @@ export function useSuspenseUsersId<
 >(
   args: InferRequestType<(typeof client.users)[':id']['$get']>,
   options?: {
-    query?: UseSuspenseQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query?: Omit<
+      UseSuspenseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+          >
+        >,
+        TError,
+        TData
       >,
-      TError,
-      TData
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -4063,14 +4161,19 @@ export function useInfiniteUsersId<
     ) => InferRequestType<(typeof client.users)[':id']['$get']>
   },
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query?: Omit<
+      UseInfiniteQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+          >
+        >,
+        TError,
+        TData,
+        ReturnType<typeof getUsersIdInfiniteQueryKey>,
+        TPageParam
       >,
-      TError,
-      TData,
-      ReturnType<typeof getUsersIdInfiniteQueryKey>,
-      TPageParam
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -4123,14 +4226,19 @@ export function useSuspenseInfiniteUsersId<
     ) => InferRequestType<(typeof client.users)[':id']['$get']>
   },
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query?: Omit<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+          >
+        >,
+        TError,
+        TData,
+        ReturnType<typeof getUsersIdInfiniteQueryKey>,
+        TPageParam
       >,
-      TError,
-      TData,
-      ReturnType<typeof getUsersIdInfiniteQueryKey>,
-      TPageParam
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -4470,12 +4578,17 @@ export function useUsersId<
 >(
   args: InferRequestType<(typeof client.users)[':id']['$get']>,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query?: Omit<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+          >
+        >,
+        TError,
+        TData
       >,
-      TError,
-      TData
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -4503,12 +4616,17 @@ export function useSuspenseUsersId<
 >(
   args: InferRequestType<(typeof client.users)[':id']['$get']>,
   options?: {
-    query?: UseSuspenseQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query?: Omit<
+      UseSuspenseQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+          >
+        >,
+        TError,
+        TData
       >,
-      TError,
-      TData
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -4601,14 +4719,19 @@ export function useInfiniteUsersId<
     ) => InferRequestType<(typeof client.users)[':id']['$get']>
   },
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query?: Omit<
+      UseInfiniteQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+          >
+        >,
+        TError,
+        TData,
+        ReturnType<typeof getUsersIdInfiniteQueryKey>,
+        TPageParam
       >,
-      TError,
-      TData,
-      ReturnType<typeof getUsersIdInfiniteQueryKey>,
-      TPageParam
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -4661,14 +4784,19 @@ export function useSuspenseInfiniteUsersId<
     ) => InferRequestType<(typeof client.users)[':id']['$get']>
   },
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query?: Omit<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+          >
+        >,
+        TError,
+        TData,
+        ReturnType<typeof getUsersIdInfiniteQueryKey>,
+        TPageParam
       >,
-      TError,
-      TData,
-      ReturnType<typeof getUsersIdInfiniteQueryKey>,
-      TPageParam
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -4739,10 +4867,13 @@ export function useUsers<
 >(
   args: InferRequestType<typeof client.users.$get>,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -4765,10 +4896,13 @@ export function useSuspenseUsers<
 >(
   args: InferRequestType<typeof client.users.$get>,
   options?: {
-    query?: UseSuspenseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -4854,12 +4988,15 @@ export function useInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -4910,12 +5047,15 @@ export function useSuspenseInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -5043,10 +5183,13 @@ export function useUsers<
 >(
   args: InferRequestType<typeof client.users.$get>,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -5069,10 +5212,13 @@ export function useSuspenseUsers<
 >(
   args: InferRequestType<typeof client.users.$get>,
   options?: {
-    query?: UseSuspenseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -5159,12 +5305,15 @@ export function useInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -5215,12 +5364,15 @@ export function useSuspenseInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -5349,10 +5501,13 @@ export function useHono<
   TData = Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
   TError = unknown,
 >(options?: {
-  query?: UseQueryOptions<
-    Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-    TError,
-    TData
+  query?: Omit<
+    UseQueryOptions<
+      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+      TError,
+      TData
+    >,
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -5372,10 +5527,13 @@ export function useSuspenseHono<
   TData = Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
   TError = unknown,
 >(options?: {
-  query?: UseSuspenseQueryOptions<
-    Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-    TError,
-    TData
+  query?: Omit<
+    UseSuspenseQueryOptions<
+      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+      TError,
+      TData
+    >,
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -5452,12 +5610,15 @@ export function useInfiniteHono<
     getRequestArgs: (pageParam: unknown) => InferRequestType<typeof client.hono.$get>
   },
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getHonoInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getHonoInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -5504,12 +5665,15 @@ export function useSuspenseInfiniteHono<
     getRequestArgs: (pageParam: unknown) => InferRequestType<typeof client.hono.$get>
   },
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getHonoInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getHonoInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -5558,10 +5722,13 @@ export function useUsers<
 >(
   args: InferRequestType<typeof client.users.$get>,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -5584,10 +5751,13 @@ export function useSuspenseUsers<
 >(
   args: InferRequestType<typeof client.users.$get>,
   options?: {
-    query?: UseSuspenseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -5673,12 +5843,15 @@ export function useInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -5729,12 +5902,15 @@ export function useSuspenseInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -5872,10 +6048,13 @@ export function useUsers<
 >(
   args: InferRequestType<typeof client.users.$get>,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -5898,10 +6077,13 @@ export function useSuspenseUsers<
 >(
   args: InferRequestType<typeof client.users.$get>,
   options?: {
-    query?: UseSuspenseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -5988,12 +6170,15 @@ export function useInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: {
-    query?: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -6044,12 +6229,15 @@ export function useSuspenseInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: {
-    query?: UseSuspenseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      UseSuspenseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -6163,12 +6351,15 @@ export function createHono<
   TError = unknown,
 >(
   options?: () => {
-    query?: ReturnType<
-      UndefinedInitialDataOptions<
-        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-        TError,
-        TData
-      >
+    query?: Omit<
+      ReturnType<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+          TError,
+          TData
+        >
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -6214,12 +6405,15 @@ export function createUsers<
 >(
   args: () => InferRequestType<typeof client.users.$get>,
   options?: () => {
-    query?: ReturnType<
-      UndefinedInitialDataOptions<
-        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-        TError,
-        TData
-      >
+    query?: Omit<
+      ReturnType<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          TError,
+          TData
+        >
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -6307,14 +6501,17 @@ export function createInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: () => {
-    query?: ReturnType<
-      UndefinedInitialDataInfiniteOptions<
-        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-        TError,
-        TData,
-        ReturnType<typeof getUsersInfiniteQueryKey>,
-        TPageParam
-      >
+    query?: Omit<
+      ReturnType<
+        UndefinedInitialDataInfiniteOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          TError,
+          TData,
+          ReturnType<typeof getUsersInfiniteQueryKey>,
+          TPageParam
+        >
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -6429,12 +6626,15 @@ export function createHono<
   TError = unknown,
 >(
   options?: () => {
-    query?: ReturnType<
-      UndefinedInitialDataOptions<
-        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-        TError,
-        TData
-      >
+    query?: Omit<
+      ReturnType<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+          TError,
+          TData
+        >
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -6499,12 +6699,15 @@ export function createUsers<
 >(
   args: () => InferRequestType<typeof client.users.$get>,
   options?: () => {
-    query?: ReturnType<
-      UndefinedInitialDataOptions<
-        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-        TError,
-        TData
-      >
+    query?: Omit<
+      ReturnType<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          TError,
+          TData
+        >
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -6592,14 +6795,17 @@ export function createInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: () => {
-    query?: ReturnType<
-      UndefinedInitialDataInfiniteOptions<
-        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-        TError,
-        TData,
-        ReturnType<typeof getUsersInfiniteQueryKey>,
-        TPageParam
-      >
+    query?: Omit<
+      ReturnType<
+        UndefinedInitialDataInfiniteOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          TError,
+          TData,
+          ReturnType<typeof getUsersInfiniteQueryKey>,
+          TPageParam
+        >
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -6767,10 +6973,18 @@ export function useHono<
   TData = Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
   TError = unknown,
 >(options?: {
-  query?: UseQueryOptions<
-    Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-    TError,
-    TData
+  query?: Omit<
+    Extract<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+        TError,
+        TData,
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+        ReturnType<typeof getHonoQueryKey>
+      >,
+      { queryKey: unknown }
+    >,
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -6817,12 +7031,18 @@ export function useInfiniteHono<
 >(
   pagination: { getRequestArgs: (pageParam: unknown) => InferRequestType<typeof client.hono.$get> },
   options: {
-    query: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getHonoInfiniteQueryKey>,
-      TPageParam
+    query: Omit<
+      Extract<
+        UseInfiniteQueryOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+          TError,
+          TData,
+          ReturnType<typeof getHonoInfiniteQueryKey>,
+          TPageParam
+        >,
+        { queryKey: unknown }
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -6868,10 +7088,18 @@ export function useUsers<
 >(
   args: MaybeRefOrGetter<InferRequestType<typeof client.users.$get>>,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      Extract<
+        UseQueryOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          TError,
+          TData,
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          ReturnType<typeof getUsersQueryKey>
+        >,
+        { queryKey: unknown }
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -6936,12 +7164,18 @@ export function useInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options: {
-    query: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query: Omit<
+      Extract<
+        UseInfiniteQueryOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          TError,
+          TData,
+          ReturnType<typeof getUsersInfiniteQueryKey>,
+          TPageParam
+        >,
+        { queryKey: unknown }
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -7051,10 +7285,18 @@ export function useHono<
   TData = Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
   TError = unknown,
 >(options?: {
-  query?: UseQueryOptions<
-    Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-    TError,
-    TData
+  query?: Omit<
+    Extract<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+        TError,
+        TData,
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+        ReturnType<typeof getHonoQueryKey>
+      >,
+      { queryKey: unknown }
+    >,
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -7101,12 +7343,18 @@ export function useInfiniteHono<
 >(
   pagination: { getRequestArgs: (pageParam: unknown) => InferRequestType<typeof client.hono.$get> },
   options: {
-    query: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getHonoInfiniteQueryKey>,
-      TPageParam
+    query: Omit<
+      Extract<
+        UseInfiniteQueryOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+          TError,
+          TData,
+          ReturnType<typeof getHonoInfiniteQueryKey>,
+          TPageParam
+        >,
+        { queryKey: unknown }
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -7168,10 +7416,18 @@ export function useUsers<
 >(
   args: MaybeRefOrGetter<InferRequestType<typeof client.users.$get>>,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      Extract<
+        UseQueryOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          TError,
+          TData,
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          ReturnType<typeof getUsersQueryKey>
+        >,
+        { queryKey: unknown }
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -7236,12 +7492,18 @@ export function useInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options: {
-    query: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query: Omit<
+      Extract<
+        UseInfiniteQueryOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          TError,
+          TData,
+          ReturnType<typeof getUsersInfiniteQueryKey>,
+          TPageParam
+        >,
+        { queryKey: unknown }
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -7376,10 +7638,22 @@ export function useUsers<
   >,
   TError = unknown,
 >(options?: {
-  query?: UseQueryOptions<
-    Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>>,
-    TError,
-    TData
+  query?: Omit<
+    Extract<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>
+        >,
+        TError,
+        TData,
+        Awaited<
+          ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>
+        >,
+        ReturnType<typeof getUsersQueryKey>
+      >,
+      { queryKey: unknown }
+    >,
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -7435,12 +7709,20 @@ export function useInfiniteUsers<
     getRequestArgs: (pageParam: unknown) => InferRequestType<typeof authClient.users.$get>
   },
   options: {
-    query: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query: Omit<
+      Extract<
+        UseInfiniteQueryOptions<
+          Awaited<
+            ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>
+          >,
+          TError,
+          TData,
+          ReturnType<typeof getUsersInfiniteQueryKey>,
+          TPageParam
+        >,
+        { queryKey: unknown }
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -7528,10 +7810,18 @@ export function usePing<
   TData = Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
   TError = unknown,
 >(options?: {
-  query?: UseQueryOptions<
-    Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
-    TError,
-    TData
+  query?: Omit<
+    Extract<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
+        TError,
+        TData,
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
+        ReturnType<typeof getPingQueryKey>
+      >,
+      { queryKey: unknown }
+    >,
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -7578,12 +7868,18 @@ export function useInfinitePing<
 >(
   pagination: { getRequestArgs: (pageParam: unknown) => InferRequestType<typeof client.ping.$get> },
   options: {
-    query: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getPingInfiniteQueryKey>,
-      TPageParam
+    query: Omit<
+      Extract<
+        UseInfiniteQueryOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
+          TError,
+          TData,
+          ReturnType<typeof getPingInfiniteQueryKey>,
+          TPageParam
+        >,
+        { queryKey: unknown }
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -7699,12 +7995,22 @@ export function useHonoX<
   >,
   TError = unknown,
 >(options?: {
-  query?: UseQueryOptions<
-    Awaited<
-      ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+  query?: Omit<
+    Extract<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+        >,
+        TError,
+        TData,
+        Awaited<
+          ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+        >,
+        ReturnType<typeof getHonoXQueryKey>
+      >,
+      { queryKey: unknown }
     >,
-    TError,
-    TData
+    'queryKey' | 'queryFn'
   >
   options?: ClientRequestOptions
 }) {
@@ -7760,14 +8066,20 @@ export function useInfiniteHonoX<
     getRequestArgs: (pageParam: unknown) => InferRequestType<(typeof client)['hono-x']['$get']>
   },
   options: {
-    query: UseInfiniteQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+    query: Omit<
+      Extract<
+        UseInfiniteQueryOptions<
+          Awaited<
+            ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+          >,
+          TError,
+          TData,
+          ReturnType<typeof getHonoXInfiniteQueryKey>,
+          TPageParam
+        >,
+        { queryKey: unknown }
       >,
-      TError,
-      TData,
-      ReturnType<typeof getHonoXInfiniteQueryKey>,
-      TPageParam
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -7871,12 +8183,26 @@ export function useUsersId<
 >(
   args: MaybeRefOrGetter<InferRequestType<(typeof client.users)[':id']['$get']>>,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query?: Omit<
+      Extract<
+        UseQueryOptions<
+          Awaited<
+            ReturnType<
+              typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+            >
+          >,
+          TError,
+          TData,
+          Awaited<
+            ReturnType<
+              typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+            >
+          >,
+          ReturnType<typeof getUsersIdQueryKey>
+        >,
+        { queryKey: unknown }
       >,
-      TError,
-      TData
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -7943,14 +8269,22 @@ export function useInfiniteUsersId<
     ) => InferRequestType<(typeof client.users)[':id']['$get']>
   },
   options: {
-    query: UseInfiniteQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query: Omit<
+      Extract<
+        UseInfiniteQueryOptions<
+          Awaited<
+            ReturnType<
+              typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+            >
+          >,
+          TError,
+          TData,
+          ReturnType<typeof getUsersIdInfiniteQueryKey>,
+          TPageParam
+        >,
+        { queryKey: unknown }
       >,
-      TError,
-      TData,
-      ReturnType<typeof getUsersIdInfiniteQueryKey>,
-      TPageParam
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -8135,10 +8469,18 @@ export function useUsers<
 >(
   args: MaybeRefOrGetter<InferRequestType<typeof client.users.$get>>,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      Extract<
+        UseQueryOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          TError,
+          TData,
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          ReturnType<typeof getUsersQueryKey>
+        >,
+        { queryKey: unknown }
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -8203,12 +8545,18 @@ export function useInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options: {
-    query: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query: Omit<
+      Extract<
+        UseInfiniteQueryOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          TError,
+          TData,
+          ReturnType<typeof getUsersInfiniteQueryKey>,
+          TPageParam
+        >,
+        { queryKey: unknown }
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -8314,12 +8662,26 @@ export function useUsersId<
 >(
   args: MaybeRefOrGetter<InferRequestType<(typeof client.users)[':id']['$get']>>,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query?: Omit<
+      Extract<
+        UseQueryOptions<
+          Awaited<
+            ReturnType<
+              typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+            >
+          >,
+          TError,
+          TData,
+          Awaited<
+            ReturnType<
+              typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+            >
+          >,
+          ReturnType<typeof getUsersIdQueryKey>
+        >,
+        { queryKey: unknown }
       >,
-      TError,
-      TData
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -8386,14 +8748,22 @@ export function useInfiniteUsersId<
     ) => InferRequestType<(typeof client.users)[':id']['$get']>
   },
   options: {
-    query: UseInfiniteQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query: Omit<
+      Extract<
+        UseInfiniteQueryOptions<
+          Awaited<
+            ReturnType<
+              typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+            >
+          >,
+          TError,
+          TData,
+          ReturnType<typeof getUsersIdInfiniteQueryKey>,
+          TPageParam
+        >,
+        { queryKey: unknown }
       >,
-      TError,
-      TData,
-      ReturnType<typeof getUsersIdInfiniteQueryKey>,
-      TPageParam
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -8735,10 +9105,18 @@ export function useUsers<
 >(
   args: MaybeRefOrGetter<InferRequestType<typeof client.users.$get>>,
   options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      Extract<
+        UseQueryOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          TError,
+          TData,
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          ReturnType<typeof getUsersQueryKey>
+        >,
+        { queryKey: unknown }
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -8804,12 +9182,18 @@ export function useInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options: {
-    query: UseInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query: Omit<
+      Extract<
+        UseInfiniteQueryOptions<
+          Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+          TError,
+          TData,
+          ReturnType<typeof getUsersInfiniteQueryKey>,
+          TPageParam
+        >,
+        { queryKey: unknown }
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -8941,10 +9325,13 @@ export function createPets<
 >(
   args: () => InferRequestType<typeof client.pets.$get>,
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.pets.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.pets.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -9032,12 +9419,15 @@ export function createInfinitePets<
     ) => InferRequestType<typeof client.pets.$get>
   },
   options?: () => {
-    query?: CreateInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.pets.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getPetsInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      CreateInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.pets.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getPetsInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -9118,14 +9508,17 @@ export function createPetsPetId<
 >(
   args: () => InferRequestType<(typeof client.pets)[':petId']['$get']>,
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<
-        ReturnType<
-          typeof parseResponse<Awaited<ReturnType<(typeof client.pets)[':petId']['$get']>>>
-        >
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.pets)[':petId']['$get']>>>
+          >
+        >,
+        TError,
+        TData
       >,
-      TError,
-      TData
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -9228,16 +9621,19 @@ export function createInfinitePetsPetId<
     ) => InferRequestType<(typeof client.pets)[':petId']['$get']>
   },
   options?: () => {
-    query?: CreateInfiniteQueryOptions<
-      Awaited<
-        ReturnType<
-          typeof parseResponse<Awaited<ReturnType<(typeof client.pets)[':petId']['$get']>>>
-        >
+    query?: Omit<
+      CreateInfiniteQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.pets)[':petId']['$get']>>>
+          >
+        >,
+        TError,
+        TData,
+        ReturnType<typeof getPetsPetIdInfiniteQueryKey>,
+        TPageParam
       >,
-      TError,
-      TData,
-      ReturnType<typeof getPetsPetIdInfiniteQueryKey>,
-      TPageParam
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -9396,10 +9792,13 @@ export function createPets<
 >(
   args: () => InferRequestType<typeof client.pets.$get>,
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.pets.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.pets.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -9487,12 +9886,15 @@ export function createInfinitePets<
     ) => InferRequestType<typeof client.pets.$get>
   },
   options?: () => {
-    query?: CreateInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.pets.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getPetsInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      CreateInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.pets.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getPetsInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -9570,14 +9972,17 @@ export function createPetsPetId<
 >(
   args: () => InferRequestType<(typeof client.pets)[':petId']['$get']>,
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<
-        ReturnType<
-          typeof parseResponse<Awaited<ReturnType<(typeof client.pets)[':petId']['$get']>>>
-        >
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.pets)[':petId']['$get']>>>
+          >
+        >,
+        TError,
+        TData
       >,
-      TError,
-      TData
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -9680,16 +10085,19 @@ export function createInfinitePetsPetId<
     ) => InferRequestType<(typeof client.pets)[':petId']['$get']>
   },
   options?: () => {
-    query?: CreateInfiniteQueryOptions<
-      Awaited<
-        ReturnType<
-          typeof parseResponse<Awaited<ReturnType<(typeof client.pets)[':petId']['$get']>>>
-        >
+    query?: Omit<
+      CreateInfiniteQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.pets)[':petId']['$get']>>>
+          >
+        >,
+        TError,
+        TData,
+        ReturnType<typeof getPetsPetIdInfiniteQueryKey>,
+        TPageParam
       >,
-      TError,
-      TData,
-      ReturnType<typeof getPetsPetIdInfiniteQueryKey>,
-      TPageParam
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -9921,10 +10329,15 @@ export function createUsers<
   TError = unknown,
 >(
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<
+          ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>
+        >,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -10007,12 +10420,17 @@ export function createInfiniteUsers<
     getRequestArgs: (pageParam: unknown) => InferRequestType<typeof authClient.users.$get>
   },
   options?: () => {
-    query?: CreateInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      CreateInfiniteQueryOptions<
+        Awaited<
+          ReturnType<typeof parseResponse<Awaited<ReturnType<typeof authClient.users.$get>>>>
+        >,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -10119,10 +10537,13 @@ export function createPing<
   TError = unknown,
 >(
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -10205,12 +10626,15 @@ export function createInfinitePing<
     getRequestArgs: (pageParam: unknown) => InferRequestType<typeof client.ping.$get>
   },
   options?: () => {
-    query?: CreateInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getPingInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      CreateInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.ping.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getPingInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -10338,12 +10762,15 @@ export function createHonoX<
   TError = unknown,
 >(
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<
+          ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+        >,
+        TError,
+        TData
       >,
-      TError,
-      TData
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -10428,14 +10855,17 @@ export function createInfiniteHonoX<
     getRequestArgs: (pageParam: unknown) => InferRequestType<(typeof client)['hono-x']['$get']>
   },
   options?: () => {
-    query?: CreateInfiniteQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+    query?: Omit<
+      CreateInfiniteQueryOptions<
+        Awaited<
+          ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client)['hono-x']['$get']>>>>
+        >,
+        TError,
+        TData,
+        ReturnType<typeof getHonoXInfiniteQueryKey>,
+        TPageParam
       >,
-      TError,
-      TData,
-      ReturnType<typeof getHonoXInfiniteQueryKey>,
-      TPageParam
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -10549,12 +10979,17 @@ export function createUsersId<
 >(
   args: () => InferRequestType<(typeof client.users)[':id']['$get']>,
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+          >
+        >,
+        TError,
+        TData
       >,
-      TError,
-      TData
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -10649,14 +11084,19 @@ export function createInfiniteUsersId<
     ) => InferRequestType<(typeof client.users)[':id']['$get']>
   },
   options?: () => {
-    query?: CreateInfiniteQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query?: Omit<
+      CreateInfiniteQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+          >
+        >,
+        TError,
+        TData,
+        ReturnType<typeof getUsersIdInfiniteQueryKey>,
+        TPageParam
       >,
-      TError,
-      TData,
-      ReturnType<typeof getUsersIdInfiniteQueryKey>,
-      TPageParam
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -10839,10 +11279,13 @@ export function createUsers<
 >(
   args: () => InferRequestType<typeof client.users.$get>,
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -10930,12 +11373,15 @@ export function createInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: () => {
-    query?: CreateInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      CreateInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -11044,12 +11490,17 @@ export function createUsersId<
 >(
   args: () => InferRequestType<(typeof client.users)[':id']['$get']>,
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+          >
+        >,
+        TError,
+        TData
       >,
-      TError,
-      TData
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -11144,14 +11595,19 @@ export function createInfiniteUsersId<
     ) => InferRequestType<(typeof client.users)[':id']['$get']>
   },
   options?: () => {
-    query?: CreateInfiniteQueryOptions<
-      Awaited<
-        ReturnType<typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>>
+    query?: Omit<
+      CreateInfiniteQueryOptions<
+        Awaited<
+          ReturnType<
+            typeof parseResponse<Awaited<ReturnType<(typeof client.users)[':id']['$get']>>>
+          >
+        >,
+        TError,
+        TData,
+        ReturnType<typeof getUsersIdInfiniteQueryKey>,
+        TPageParam
       >,
-      TError,
-      TData,
-      ReturnType<typeof getUsersIdInfiniteQueryKey>,
-      TPageParam
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -11355,10 +11811,13 @@ export function createUsers<
 >(
   args: () => InferRequestType<typeof client.users.$get>,
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -11447,12 +11906,15 @@ export function createInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: () => {
-    query?: CreateInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      CreateInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -11569,10 +12031,13 @@ export function injectHono<
   TError = unknown,
 >(
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -11618,10 +12083,13 @@ export function injectUsers<
 >(
   args: () => InferRequestType<typeof client.users.$get>,
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -11709,12 +12177,15 @@ export function injectInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: () => {
-    query?: CreateInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      CreateInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },
@@ -11828,10 +12299,13 @@ export function injectHono<
   TError = unknown,
 >(
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -11906,10 +12380,13 @@ export function injectHono<
   TError = unknown,
 >(
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.hono.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -11974,10 +12451,13 @@ export function injectUsers<
 >(
   args: () => InferRequestType<typeof client.users.$get>,
   options?: () => {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData
+    query?: Omit<
+      CreateQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData
+      >,
+      'queryKey' | 'queryFn'
     >
     options?: ClientRequestOptions
   },
@@ -12065,12 +12545,15 @@ export function injectInfiniteUsers<
     ) => InferRequestType<typeof client.users.$get>
   },
   options?: () => {
-    query?: CreateInfiniteQueryOptions<
-      Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
-      TError,
-      TData,
-      ReturnType<typeof getUsersInfiniteQueryKey>,
-      TPageParam
+    query?: Omit<
+      CreateInfiniteQueryOptions<
+        Awaited<ReturnType<typeof parseResponse<Awaited<ReturnType<typeof client.users.$get>>>>>,
+        TError,
+        TData,
+        ReturnType<typeof getUsersInfiniteQueryKey>,
+        TPageParam
+      >,
+      'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam'
     >
     options?: ClientRequestOptions
   },

--- a/packages/hono-takibi/src/helper/query.ts
+++ b/packages/hono-takibi/src/helper/query.ts
@@ -25,6 +25,21 @@ function wrapOptionsType(optionsType: string, unwrapAccessor?: boolean) {
   return unwrapAccessor ? `ReturnType<${optionsType}>` : optionsType
 }
 
+// The hook supplies these itself, so `options.query` leaves them out — the shape
+// openapi-react-query uses. The libraries type `queryKey` as required, which otherwise forces the
+// caller to pass a key the hook then overwrites, and leaves `select` unable to bind TData.
+const QUERY_OMIT_KEYS = `'queryKey'|'queryFn'`
+// Infinite hooks with the helper also supply both page-param functions, from `pagination`.
+const INFINITE_OMIT_KEYS = `'queryKey'|'queryFn'|'initialPageParam'|'getNextPageParam'`
+
+// Vue's option types are `MaybeRef<{...}>` (`Ref | ComputedRef | object`), and a plain `Omit` over
+// that union keeps only the keys all three share — none. The hook spreads the value, which only
+// works on the plain object anyway, so `Extract` keeps that member (the only one with `queryKey`).
+function omitInjectedKeys(optionsType: string, keys: string, isVueQuery?: boolean) {
+  const objectType = isVueQuery ? `Extract<${optionsType},{queryKey:unknown}>` : optionsType
+  return `Omit<${objectType},${keys}>`
+}
+
 function makeHookName(method: string, pathStr: string, prefix: string) {
   const funcName = methodPath(method, pathStr)
   return `${prefix}${capitalize(funcName)}`
@@ -397,9 +412,18 @@ function makeQueryHookCode(
   // TData first so callers can override `select`'s output type without naming TError:
   //   useUsers<string[]>(args, { query: { select: (data) => data.map(u => u.name) } })
   const generics = `<TData=${responseType},TError=${errorType}>`
-  const queryOptionsType = wrapOptionsType(
-    `${config.useQueryOptionsType}<${responseType},TError,TData>`,
-    config.unwrapOptionsAccessor,
+  // Vue spells out TQueryKey (via its 5-parameter form): left at the `QueryKey` default, the
+  // options' key-typed members (`persister`, …) clash with the narrow key the hook supplies.
+  const optionsTypeArgs = config.isVueQuery
+    ? `${responseType},TError,TData,${responseType},ReturnType<typeof ${keyGetterName}>`
+    : `${responseType},TError,TData`
+  const queryOptionsType = omitInjectedKeys(
+    wrapOptionsType(
+      `${config.useQueryOptionsType}<${optionsTypeArgs}>`,
+      config.unwrapOptionsAccessor,
+    ),
+    QUERY_OMIT_KEYS,
+    config.isVueQuery,
   )
   const optionsType = `{query?:${queryOptionsType};options?:ClientRequestOptions}`
   const keyCall = hasArgs ? `${keyGetterName}(args)` : `${keyGetterName}()`
@@ -484,9 +508,14 @@ function makeInfiniteQueryHookCode(
   const tDataDefault = useHelper ? `InfiniteData<${responseType}>` : responseType
   const generics = `<TData=${tDataDefault},TError=${errorType},TPageParam=unknown>`
   const queryKeyType = `ReturnType<typeof ${infiniteKeyGetterName}>`
-  const queryOptionsType = wrapOptionsType(
-    `${config.useInfiniteQueryOptionsType}<${responseType},TError,TData,${queryKeyType},TPageParam>`,
-    config.unwrapOptionsAccessor,
+  // Without the helper (Vue) the page-param functions travel in `options.query`, so they stay.
+  const queryOptionsType = omitInjectedKeys(
+    wrapOptionsType(
+      `${config.useInfiniteQueryOptionsType}<${responseType},TError,TData,${queryKeyType},TPageParam>`,
+      config.unwrapOptionsAccessor,
+    ),
+    useHelper ? INFINITE_OMIT_KEYS : QUERY_OMIT_KEYS,
+    config.isVueQuery,
   )
   const optionsType = useHelper
     ? `{query?:${queryOptionsType};options?:ClientRequestOptions}`

--- a/test/types/angular-query.ts
+++ b/test/types/angular-query.ts
@@ -1,6 +1,13 @@
 // angular-query: the hook's generics must reach the caller, not degrade to `any` or the library default.
-import { injectPostUsers, injectUsers } from '../__generated__/angular-query/hooks'
-import { assertType, type NotAny } from './assert'
+import {
+  injectInfiniteItems,
+  injectPostUsers,
+  injectUsers,
+} from '../__generated__/angular-query/hooks'
+import { type Equal, type HasKey, type IsAssignable, type NotAny, assertType } from './assert'
+
+/** The options slot of the plain query hook, as the caller sees it. */
+type QuerySlot = NonNullable<ReturnType<NonNullable<Parameters<typeof injectUsers>[0]>>['query']>
 
 type ApiError = { readonly code: number }
 type Rollback = { readonly prev: readonly string[] }
@@ -22,4 +29,39 @@ export function assertions() {
   const mutationError: ApiError | null = mutation.error()
   const rows: { id: string; name: string }[] | undefined = query.data()
   return { query, mutation, mutationError, rows }
+}
+
+// The hook supplies `queryKey` / `queryFn`, so `options.query` must not demand them: the library
+// types `queryKey` as required, which forced callers to pass a key the hook then overwrote.
+export function queryOptionsAssertions() {
+  const disabled = injectUsers(() => ({ query: { enabled: false } }))
+
+  // `select` binds TData through the slot — the usage documented in helper/query.ts.
+  const names = injectUsers<string[]>(() => ({
+    query: { select: (data) => data.map((u) => u.name) },
+  }))
+  const selected = injectUsers(() => ({ query: { select: (users) => users.length } }))
+  assertType<Equal<ReturnType<typeof selected.data>, number | undefined>>(true)
+
+  // The options stay typed: a right-typed value is accepted, a wrong-typed one is not.
+  assertType<IsAssignable<{ staleTime: 1_000 }, QuerySlot>>(true)
+  assertType<Equal<IsAssignable<{ staleTime: 'soon' }, QuerySlot>, false>>(true)
+  // The key is the hook's own — a caller's would be silently overwritten — so the slot has none.
+  assertType<Equal<HasKey<QuerySlot, 'queryKey'>, false>>(true)
+  assertType<Equal<HasKey<QuerySlot, 'queryFn'>, false>>(true)
+
+  // The infinite hook also supplies both page-param functions, from `pagination`.
+  const infinite = injectInfiniteItems(
+    () => ({ query: { page: '0' } }),
+    {
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => lastPage.nextPage,
+      getRequestArgs: (args, pageParam) => ({
+        ...args,
+        query: { ...args.query, page: String(pageParam) },
+      }),
+    },
+    () => ({ query: { staleTime: 1_000 } }),
+  )
+  return { disabled, names, selected, infinite }
 }

--- a/test/types/assert.ts
+++ b/test/types/assert.ts
@@ -12,3 +12,24 @@ export type NotAny<T> = IsAny<T> extends false ? true : false
  */
 // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- the constraint on T is the assertion
 export const assertType = <T extends true>(_assertion: T): void => undefined
+
+/**
+ * `true` only when A and B are the same type: each is assignable to the other — one direction is
+ * not enough — and `any` on either side matches only `any`, since it is assignable both ways.
+ */
+export type Equal<A, B> =
+  IsAny<A> extends true
+    ? IsAny<B>
+    : IsAny<B> extends true
+      ? false
+      : [A] extends [B]
+        ? [B] extends [A]
+          ? true
+          : false
+        : false
+
+/** `true` when A is assignable to B. */
+export type IsAssignable<A, B> = [A] extends [B] ? true : false
+
+/** `true` when T declares the key K. */
+export type HasKey<T, K extends PropertyKey> = K extends keyof T ? true : false

--- a/test/types/preact-query.ts
+++ b/test/types/preact-query.ts
@@ -1,6 +1,14 @@
 // preact-query: the hook's generics must reach the caller, not degrade to `any` or the library default.
-import { usePostUsers, useUsers } from '../__generated__/preact-query/hooks'
-import { assertType, type NotAny } from './assert'
+import {
+  useInfiniteItems,
+  usePostUsers,
+  useSuspenseUsers,
+  useUsers,
+} from '../__generated__/preact-query/hooks'
+import { type Equal, type HasKey, type IsAssignable, type NotAny, assertType } from './assert'
+
+/** The options slot of the plain query hook, as the caller sees it. */
+type QuerySlot = NonNullable<NonNullable<Parameters<typeof useUsers>[0]>['query']>
 
 type ApiError = { readonly code: number }
 type Rollback = { readonly prev: readonly string[] }
@@ -22,4 +30,40 @@ export function assertions() {
   const mutationError: ApiError | null = mutation.error
   const rows: { id: string; name: string }[] | undefined = query.data
   return { query, mutation, mutationError, rows }
+}
+
+// The hook supplies `queryKey` / `queryFn`, so `options.query` must not demand them: the library
+// types `queryKey` as required, which forced callers to pass a key the hook then overwrote.
+export function queryOptionsAssertions() {
+  const disabled = useUsers({ query: { enabled: false } })
+
+  // `select` binds TData through the slot — the usage documented in helper/query.ts.
+  const names = useUsers<string[]>({ query: { select: (data) => data.map((u) => u.name) } })
+  const selected = useUsers({ query: { select: (users) => users.length } })
+  assertType<Equal<typeof selected.data, number | undefined>>(true)
+
+  // The options stay typed: a right-typed value is accepted, a wrong-typed one is not.
+  assertType<IsAssignable<{ staleTime: 1_000 }, QuerySlot>>(true)
+  assertType<Equal<IsAssignable<{ staleTime: 'soon' }, QuerySlot>, false>>(true)
+  // The key is the hook's own — a caller's would be silently overwritten — so the slot has none.
+  assertType<Equal<HasKey<QuerySlot, 'queryKey'>, false>>(true)
+  assertType<Equal<HasKey<QuerySlot, 'queryFn'>, false>>(true)
+
+  // The infinite hook also supplies both page-param functions, from `pagination`.
+  const infinite = useInfiniteItems(
+    { query: { page: '0' } },
+    {
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => lastPage.nextPage,
+      getRequestArgs: (args, pageParam) => ({
+        ...args,
+        query: { ...args.query, page: String(pageParam) },
+      }),
+    },
+    { query: { staleTime: 1_000 } },
+  )
+
+  const suspense = useSuspenseUsers({ query: { select: (users) => users.length } })
+  assertType<Equal<typeof suspense.data, number>>(true)
+  return { disabled, names, selected, infinite, suspense }
 }

--- a/test/types/solid-query.ts
+++ b/test/types/solid-query.ts
@@ -1,6 +1,13 @@
 // solid-query: the hook's generics must reach the caller, not degrade to `any` or the library default.
-import { createPostUsers, createUsers } from '../__generated__/solid-query/hooks'
-import { assertType, type NotAny } from './assert'
+import {
+  createInfiniteItems,
+  createPostUsers,
+  createUsers,
+} from '../__generated__/solid-query/hooks'
+import { type Equal, type HasKey, type IsAssignable, type NotAny, assertType } from './assert'
+
+/** The options slot of the plain query hook, as the caller sees it. */
+type QuerySlot = NonNullable<ReturnType<NonNullable<Parameters<typeof createUsers>[0]>>['query']>
 
 type ApiError = { readonly code: number }
 type Rollback = { readonly prev: readonly string[] }
@@ -22,4 +29,39 @@ export function assertions() {
   const mutationError: ApiError | null = mutation.error
   const rows: { id: string; name: string }[] | undefined = query.data
   return { query, mutation, mutationError, rows }
+}
+
+// The hook supplies `queryKey` / `queryFn`, so `options.query` must not demand them: the library
+// types `queryKey` as required, which forced callers to pass a key the hook then overwrote.
+export function queryOptionsAssertions() {
+  const disabled = createUsers(() => ({ query: { enabled: false } }))
+
+  // `select` binds TData through the slot — the usage documented in helper/query.ts.
+  const names = createUsers<string[]>(() => ({
+    query: { select: (data) => data.map((u) => u.name) },
+  }))
+  const selected = createUsers(() => ({ query: { select: (users) => users.length } }))
+  assertType<Equal<typeof selected.data, number | undefined>>(true)
+
+  // The options stay typed: a right-typed value is accepted, a wrong-typed one is not.
+  assertType<IsAssignable<{ staleTime: 1_000 }, QuerySlot>>(true)
+  assertType<Equal<IsAssignable<{ staleTime: 'soon' }, QuerySlot>, false>>(true)
+  // The key is the hook's own — a caller's would be silently overwritten — so the slot has none.
+  assertType<Equal<HasKey<QuerySlot, 'queryKey'>, false>>(true)
+  assertType<Equal<HasKey<QuerySlot, 'queryFn'>, false>>(true)
+
+  // The infinite hook also supplies both page-param functions, from `pagination`.
+  const infinite = createInfiniteItems(
+    () => ({ query: { page: '0' } }),
+    {
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => lastPage.nextPage,
+      getRequestArgs: (args, pageParam) => ({
+        ...args,
+        query: { ...args.query, page: String(pageParam) },
+      }),
+    },
+    () => ({ query: { staleTime: 1_000 } }),
+  )
+  return { disabled, names, selected, infinite }
 }

--- a/test/types/svelte-query.ts
+++ b/test/types/svelte-query.ts
@@ -1,6 +1,13 @@
 // svelte-query: the hook's generics must reach the caller, not degrade to `any` or the library default.
-import { createPostUsers, createUsers } from '../__generated__/svelte-query/hooks'
-import { assertType, type NotAny } from './assert'
+import {
+  createInfiniteItems,
+  createPostUsers,
+  createUsers,
+} from '../__generated__/svelte-query/hooks'
+import { type Equal, type HasKey, type IsAssignable, type NotAny, assertType } from './assert'
+
+/** The options slot of the plain query hook, as the caller sees it. */
+type QuerySlot = NonNullable<ReturnType<NonNullable<Parameters<typeof createUsers>[0]>>['query']>
 
 type ApiError = { readonly code: number }
 type Rollback = { readonly prev: readonly string[] }
@@ -22,4 +29,39 @@ export function assertions() {
   const mutationError: ApiError | null = mutation.error
   const rows: { id: string; name: string }[] | undefined = query.data
   return { query, mutation, mutationError, rows }
+}
+
+// The hook supplies `queryKey` / `queryFn`, so `options.query` must not demand them: the library
+// types `queryKey` as required, which forced callers to pass a key the hook then overwrote.
+export function queryOptionsAssertions() {
+  const disabled = createUsers(() => ({ query: { enabled: false } }))
+
+  // `select` binds TData through the slot — the usage documented in helper/query.ts.
+  const names = createUsers<string[]>(() => ({
+    query: { select: (data) => data.map((u) => u.name) },
+  }))
+  const selected = createUsers(() => ({ query: { select: (users) => users.length } }))
+  assertType<Equal<typeof selected.data, number | undefined>>(true)
+
+  // The options stay typed: a right-typed value is accepted, a wrong-typed one is not.
+  assertType<IsAssignable<{ staleTime: 1_000 }, QuerySlot>>(true)
+  assertType<Equal<IsAssignable<{ staleTime: 'soon' }, QuerySlot>, false>>(true)
+  // The key is the hook's own — a caller's would be silently overwritten — so the slot has none.
+  assertType<Equal<HasKey<QuerySlot, 'queryKey'>, false>>(true)
+  assertType<Equal<HasKey<QuerySlot, 'queryFn'>, false>>(true)
+
+  // The infinite hook also supplies both page-param functions, from `pagination`.
+  const infinite = createInfiniteItems(
+    () => ({ query: { page: '0' } }),
+    {
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => lastPage.nextPage,
+      getRequestArgs: (args, pageParam) => ({
+        ...args,
+        query: { ...args.query, page: String(pageParam) },
+      }),
+    },
+    () => ({ query: { staleTime: 1_000 } }),
+  )
+  return { disabled, names, selected, infinite }
 }

--- a/test/types/tanstack-query.ts
+++ b/test/types/tanstack-query.ts
@@ -1,6 +1,14 @@
 // tanstack-query: the hook's generics must reach the caller, not degrade to `any` or the library default.
-import { usePostUsers, useUsers } from '../__generated__/tanstack-query/query'
-import { assertType, type NotAny } from './assert'
+import {
+  useInfiniteItems,
+  usePostUsers,
+  useSuspenseUsers,
+  useUsers,
+} from '../__generated__/tanstack-query/query'
+import { type Equal, type HasKey, type IsAssignable, type NotAny, assertType } from './assert'
+
+/** The options slot of the plain query hook, as the caller sees it. */
+type QuerySlot = NonNullable<NonNullable<Parameters<typeof useUsers>[0]>['query']>
 
 type ApiError = { readonly code: number }
 type Rollback = { readonly prev: readonly string[] }
@@ -22,4 +30,40 @@ export function assertions() {
   const mutationError: ApiError | null = mutation.error
   const rows: { id: string; name: string }[] | undefined = query.data
   return { query, mutation, mutationError, rows }
+}
+
+// The hook supplies `queryKey` / `queryFn`, so `options.query` must not demand them: the library
+// types `queryKey` as required, which forced callers to pass a key the hook then overwrote.
+export function queryOptionsAssertions() {
+  const disabled = useUsers({ query: { enabled: false } })
+
+  // `select` binds TData through the slot — the usage documented in helper/query.ts.
+  const names = useUsers<string[]>({ query: { select: (data) => data.map((u) => u.name) } })
+  const selected = useUsers({ query: { select: (users) => users.length } })
+  assertType<Equal<typeof selected.data, number | undefined>>(true)
+
+  // The options stay typed: a right-typed value is accepted, a wrong-typed one is not.
+  assertType<IsAssignable<{ staleTime: 1_000 }, QuerySlot>>(true)
+  assertType<Equal<IsAssignable<{ staleTime: 'soon' }, QuerySlot>, false>>(true)
+  // The key is the hook's own — a caller's would be silently overwritten — so the slot has none.
+  assertType<Equal<HasKey<QuerySlot, 'queryKey'>, false>>(true)
+  assertType<Equal<HasKey<QuerySlot, 'queryFn'>, false>>(true)
+
+  // The infinite hook also supplies both page-param functions, from `pagination`.
+  const infinite = useInfiniteItems(
+    { query: { page: '0' } },
+    {
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => lastPage.nextPage,
+      getRequestArgs: (args, pageParam) => ({
+        ...args,
+        query: { ...args.query, page: String(pageParam) },
+      }),
+    },
+    { query: { staleTime: 1_000 } },
+  )
+
+  const suspense = useSuspenseUsers({ query: { select: (users) => users.length } })
+  assertType<Equal<typeof suspense.data, number>>(true)
+  return { disabled, names, selected, infinite, suspense }
 }

--- a/test/types/vue-query.ts
+++ b/test/types/vue-query.ts
@@ -1,6 +1,11 @@
 // vue-query: the hook's generics must reach the caller, not degrade to `any` or the library default.
-import { usePostUsers, useUsers } from '../__generated__/vue-query/hooks'
-import { assertType, type NotAny } from './assert'
+import { useInfiniteItems, usePostUsers, useUsers } from '../__generated__/vue-query/hooks'
+import { type Equal, type HasKey, type IsAssignable, type NotAny, assertType } from './assert'
+
+/** The options slot of the plain query hook, as the caller sees it. */
+type QuerySlot = NonNullable<NonNullable<Parameters<typeof useUsers>[0]>['query']>
+/** The options slot of the infinite hook, as the caller sees it. */
+type InfiniteSlot = Parameters<typeof useInfiniteItems>[2]['query']
 
 type ApiError = { readonly code: number }
 type Rollback = { readonly prev: readonly string[] }
@@ -22,4 +27,38 @@ export function assertions() {
   const mutationError: ApiError | null = mutation.error.value
   const rows: { id: string; name: string }[] | undefined = query.data.value
   return { query, mutation, mutationError, rows }
+}
+
+// The hook supplies `queryKey` / `queryFn`, so `options.query` must not demand them: the library
+// types `queryKey` as required, which forced callers to pass a key the hook then overwrote.
+export function queryOptionsAssertions() {
+  const disabled = useUsers({ query: { enabled: false } })
+
+  // `select` binds TData through the slot — the usage documented in helper/query.ts.
+  const names = useUsers<string[]>({ query: { select: (data) => data.map((u) => u.name) } })
+  const selected = useUsers({ query: { select: (users) => users.length } })
+  assertType<Equal<(typeof selected.data)['value'], number | undefined>>(true)
+
+  // The options stay typed: a right-typed value is accepted, a wrong-typed one is not.
+  assertType<IsAssignable<{ staleTime: 1_000 }, QuerySlot>>(true)
+  assertType<Equal<IsAssignable<{ staleTime: 'soon' }, QuerySlot>, false>>(true)
+  // The key is the hook's own — a caller's would be silently overwritten — so the slot has none.
+  assertType<Equal<HasKey<QuerySlot, 'queryKey'>, false>>(true)
+  assertType<Equal<HasKey<QuerySlot, 'queryFn'>, false>>(true)
+
+  // Vue has no infiniteQueryOptions helper, so the page-param functions travel in
+  // `options.query` and stay required there; only the key and query function are the hook's.
+  const infinite = useInfiniteItems(
+    { query: { page: '0' } },
+    {
+      getRequestArgs: (args, pageParam) => ({
+        ...args,
+        query: { ...args.query, page: String(pageParam) },
+      }),
+    },
+    { query: { initialPageParam: 0, getNextPageParam: (lastPage) => lastPage.nextPage } },
+  )
+  // The page-param functions have no other way in, so getNextPageParam stays required.
+  assertType<Equal<IsAssignable<{ initialPageParam: 0 }, InfiniteSlot>, false>>(true)
+  return { disabled, names, selected, infinite }
 }


### PR DESCRIPTION
`options.query` was typed as the library's full options type, whose `queryKey` is required, so `useUsers({ query: { enabled: false } })` failed to compile in every TanStack-family output and `select` could not bind TData, including the usage documented in helper/query.ts. It now leaves out what the hook supplies itself: `queryKey` and `queryFn`, plus the page-param functions for helper-backed infinite hooks, the shape openapi-react-query uses. Vue extracts the plain-object member of its `MaybeRef` options and spells out TQueryKey, whose `QueryKey` default otherwise clashes with the key the hook passes.

The type fixtures pin this with type-level assertions rather than `@ts-expect-error`.

<!--
Title: `type(scope): summary` — imperative mood, no trailing period. Write it for the
person reading the release notes, not for the diff.

  type   feat | fix | perf | refactor | docs | test | build | ci | chore
  scope  a generator (zod, routes, app, mock, test, docs, client, …) | openapi | cli | config
         | vite-plugin | website | test | docs | ci

  fix(zod): keep `.nullable()` on a `$ref` to a nullable component schema
  feat(cli): print the files a run wrote
-->

## Why

<!-- The bug, the missing capability or the request behind this change. Link the issue: `Closes #123`. -->

## What

<!-- What changed, as someone running the CLI or reading the generated code sees it. One to three sentences. -->

## Where

<!-- Scope: which generator (routes, Zod schemas, mock, test, docs, client hooks), the OpenAPI parser, the CLI, the config, the Vite plugin, the website. Name what is deliberately left out. -->

## Who

<!-- Who notices: every user, users of one generator or one client library, contributors only. Breaking for anyone? -->

## When

<!-- Release impact: `none` | `next release` | `version bumped to x.y.z`. -->

## How

<!--
The approach in a sentence, then the evidence. For a generator change, the spec and the
output it now writes — `test/__generated__` is not committed, so paste the lines that changed
or add a case under `test/cases`; for a website change, a screenshot of the page. Tick only
what you ran; paste the output of anything that failed.
-->

- [x] `pnpm check`
- [x] `pnpm test`
- [x] `pnpm --filter ./test typecheck`, when generated output changed
- [x] `pnpm --filter ./website test:e2e`, when the website changed
