### PR TITLE
Mock API Fix

### DIFF
--- a/packages/hono-takibi/README.md
+++ b/packages/hono-takibi/README.md
@@ -338,6 +338,17 @@ export default defineConfig({
 })
 ```
 
+Each route answers its success response by default. Like [Prism](https://stoplight.io/open-source/prism), a request can pick any response or named example the document declares with the `Prefer` header (or the `__code` / `__example` query):
+
+```bash
+curl -H 'Prefer: code=404' http://localhost:3000/orders/1          # the 404 response
+curl -H 'Prefer: example=pending' http://localhost:3000/orders/1   # a named example
+curl -H 'Prefer: code=404, example=gone' http://localhost:3000/orders/1
+curl 'http://localhost:3000/orders/1?__code=503'
+```
+
+A code falls back to its `4XX` range, then `default`. A code or example the operation does not declare answers `500` with an `application/problem+json` body saying what is missing.
+
 ## API Reference Docs
 
 Generate API reference Markdown with [hono-cli](https://github.com/honojs/cli) `hono request` commands:

--- a/packages/hono-takibi/README.md
+++ b/packages/hono-takibi/README.md
@@ -552,8 +552,9 @@ export default defineConfig({
 
   mock: {
     output: './src/mock.ts',
-    useExamples: true,
+    useExamples: true, // true: response examples | 'all': also schema/property examples | false
     locale: 'en',
+    seed: 42, // optional: same body per route on every request (snapshot-friendly)
     delay: false,
     arrayMin: 1,
     arrayMax: 10,

--- a/packages/hono-takibi/package.json
+++ b/packages/hono-takibi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono-takibi",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Hono Takibi is a code generator from OpenAPI to @hono/zod-openapi",
   "keywords": [
     "hono",

--- a/packages/hono-takibi/src/config/index.test.ts
+++ b/packages/hono-takibi/src/config/index.test.ts
@@ -368,6 +368,44 @@ describe('parseConfig()', () => {
         "Invalid config: mock.locale: Invalid faker locale. Use a code like 'ja', 'en', or 'zh_CN'.",
       )
     })
+
+    it.concurrent("accepts useExamples: 'all'", async () => {
+      const result = await runGenerator(
+        parseConfig({ input: 'openapi.yaml', mock: { output: 'src/mock.ts', useExamples: 'all' } }),
+      )
+      expect(result.mock?.useExamples).toBe('all')
+    })
+
+    it.concurrent('rejects an unknown useExamples mode', async () => {
+      const result = await runGeneratorError(
+        parseConfig({
+          input: 'openapi.yaml',
+          mock: { output: 'src/mock.ts', useExamples: 'some' },
+        }),
+      )
+      expect(result.message).toContain('Invalid config: mock.useExamples')
+    })
+
+    it.concurrent('accepts a numeric seed and an array seed', async () => {
+      const single = await runGenerator(
+        parseConfig({ input: 'openapi.yaml', mock: { output: 'src/mock.ts', seed: 42 } }),
+      )
+      expect(single.mock?.seed).toBe(42)
+      const array = await runGenerator(
+        parseConfig({ input: 'openapi.yaml', mock: { output: 'src/mock.ts', seed: [1, 2, 3] } }),
+      )
+      expect(array.mock?.seed).toStrictEqual([1, 2, 3])
+    })
+
+    it.concurrent.each([[-1], [1.5], [4_294_967_296], [[]], ['42']])(
+      'rejects the seed %j',
+      async (seed) => {
+        const result = await runGeneratorError(
+          parseConfig({ input: 'openapi.yaml', mock: { output: 'src/mock.ts', seed } }),
+        )
+        expect(result.message).toContain('Invalid config: mock.seed')
+      },
+    )
   })
 
   describe('routes.import and webhooks.import', () => {

--- a/packages/hono-takibi/src/config/index.ts
+++ b/packages/hono-takibi/src/config/index.ts
@@ -205,6 +205,13 @@ const DelayMsSchema = Schema.Number.check(
   Schema.isLessThanOrEqualTo(60_000),
 )
 
+/** A faker seed: faker hashes it with Mersenne Twister, which takes a 32-bit unsigned integer. */
+const SeedSchema = Schema.Number.check(
+  Schema.isInt(),
+  Schema.isGreaterThanOrEqualTo(0),
+  Schema.isLessThanOrEqualTo(4_294_967_295),
+)
+
 const ArrayLengthSchema = Schema.Number.check(
   Schema.isInt(),
   Schema.isGreaterThanOrEqualTo(0),
@@ -538,9 +545,18 @@ const ConfigSchema = Schema.Struct({
     Schema.Struct({
       output: FileOutputSchema,
       useExamples: Schema.optionalKey(
-        Schema.Boolean.annotate({
+        Schema.Union([Schema.Boolean, Schema.Literal('all')]).annotate({
           description:
-            'Prefer the `example` / `examples` declared in the document over faker-generated values.',
+            "Prefer the `example` / `examples` declared in the document over faker-generated values. `true` (default) uses a response's media-level example; `'all'` also uses the scalar example of every schema and property; `false` always generates.",
+          examples: [true, 'all', false],
+        }),
+      ),
+      seed: Schema.optionalKey(
+        Schema.Union([SeedSchema, Schema.NonEmptyArray(SeedSchema)]).annotate({
+          title: 'Faker seed',
+          description:
+            'Seeds faker at the start of every handler, so each route answers the same body on every request — stable enough for snapshot tests. Dates are generated relative to a fixed 2025-01-01T00:00:00Z, and the locale-specific faker instance is the one seeded.',
+          examples: [42, [1, 2, 3]],
         }),
       ),
       locale: Schema.optionalKey(
@@ -599,6 +615,7 @@ const ConfigSchema = Schema.Struct({
             output: './src/mock.ts',
             useExamples: true,
             locale: 'ja',
+            seed: 42,
             delay: { min: 100, max: 800 },
             arrayMin: 1,
             arrayMax: 10,

--- a/packages/hono-takibi/src/generator/mock/index.test.ts
+++ b/packages/hono-takibi/src/generator/mock/index.test.ts
@@ -5,9 +5,20 @@ import type { OpenAPI } from '../../openapi/index.js'
 import { runGenerator } from '../../testing/index.js'
 import { makeMock } from './index.js'
 
+// The Prism-compatible `Prefer` helpers are emitted verbatim into every mock; they
+// are pinned once (the `Prefer` suite) and stand in as one line everywhere else.
+const PREFER_HELPERS = '/* resolvePrefer, preferResponse, preferProblem */\n'
+
+function withoutPreferHelpers(code: string) {
+  return code.replace(
+    /\/\/ Reads Prism's[\s\S]*?\nfunction preferProblem\([\s\S]*?\n\}\n/u,
+    PREFER_HELPERS,
+  )
+}
+
 async function format(spec: OpenAPI, basePath: string) {
   const result = await runGenerator(fmt(makeMock(spec, basePath)))
-  return result
+  return withoutPreferHelpers(result)
 }
 
 const minimalOpenAPI = {
@@ -35,6 +46,8 @@ const minimalOpenAPI = {
 const minimalExpected = (appInit: string) =>
   `import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const getHealthRoute = createRoute({
   method: 'get',
@@ -48,7 +61,10 @@ export const getHealthRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getHealthRouteHandler: RouteHandler<typeof getHealthRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json(
     {
       status: faker.helpers.arrayElement([
@@ -123,6 +139,8 @@ describe('makeMock', () => {
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const AuthUserSchema = z
   .object({ name: z.string() })
@@ -142,7 +160,10 @@ function mockAuthUser() {
   return { name: faker.person.fullName() }
 }
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getAuthMeRouteHandler: RouteHandler<typeof getAuthMeRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json(mockAuthUser(), 200)
 }
 
@@ -202,6 +223,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const getUsersRoute = createRoute({
   method: 'get',
@@ -231,11 +254,15 @@ export const postUsersRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getUsersRouteHandler: RouteHandler<typeof getUsersRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json({ id: faker.number.int({ min: 1, max: 99999 }) }, 200)
 }
 
 const postUsersRouteHandler: RouteHandler<typeof postUsersRoute> = async (c) => {
+  resolvePrefer(c.req, { '201': [] }, '201')
   return c.json({ id: faker.number.int({ min: 1, max: 99999 }) }, 201)
 }
 
@@ -285,6 +312,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const BearerAuthSecurityScheme = { type: 'http', scheme: 'bearer' }
 
@@ -304,9 +333,15 @@ export const getMeRoute = createRoute({
   security: [{ bearerAuth: [] }],
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getMeRouteHandler: RouteHandler<typeof getMeRoute> = async (c) => {
   if (!c.req.header('Authorization')) {
     return c.json({ message: 'Unauthorized' }, 401)
+  }
+  const prefer = resolvePrefer(c.req, { '200': [], '401': [] }, '200')
+  if (prefer.key === '401') {
+    return c.body(null, 401)
   }
   return c.json({ id: faker.number.int({ min: 1, max: 99999 }) }, 200)
 }
@@ -337,6 +372,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const deletePingRoute = createRoute({
   method: 'delete',
@@ -345,7 +382,10 @@ export const deletePingRoute = createRoute({
   responses: { 204: { description: 'No Content' } },
 })
 
-const deletePingRouteHandler: RouteHandler<typeof deletePingRoute> = async (_c) => {
+/* resolvePrefer, preferResponse, preferProblem */
+
+const deletePingRouteHandler: RouteHandler<typeof deletePingRoute> = async (c) => {
+  resolvePrefer(c.req, { '204': [] }, '204')
   return new Response(null, { status: 204 })
 }
 
@@ -394,6 +434,8 @@ export default app
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
 import { getCookie } from 'hono/cookie'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const CookieAuthSecurityScheme = { type: 'apiKey', in: 'cookie', name: 'session' }
 
@@ -413,9 +455,15 @@ export const getMeRoute = createRoute({
   security: [{ cookieAuth: [] }],
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getMeRouteHandler: RouteHandler<typeof getMeRoute> = async (c) => {
   if (!getCookie(c, 'session')) {
     return c.json({ message: 'Unauthorized' }, 401)
+  }
+  const prefer = resolvePrefer(c.req, { '200': [], '401': [] }, '200')
+  if (prefer.key === '401') {
+    return c.body(null, 401)
   }
   return c.json({ id: faker.number.int({ min: 1, max: 99999 }) }, 200)
 }
@@ -464,6 +512,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const QkeySecurityScheme = { type: 'apiKey', in: 'query', name: 'api_key' }
 
@@ -483,9 +533,15 @@ export const getMeRoute = createRoute({
   security: [{ qkey: [] }],
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getMeRouteHandler: RouteHandler<typeof getMeRoute> = async (c) => {
   if (!c.req.query('api_key')) {
     return c.json({ message: 'Unauthorized' }, 401)
+  }
+  const prefer = resolvePrefer(c.req, { '200': [], '401': [] }, '200')
+  if (prefer.key === '401') {
+    return c.body(null, 401)
   }
   return c.json({ id: faker.number.int({ min: 1, max: 99999 }) }, 200)
 }
@@ -534,6 +590,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const HkeySecurityScheme = { type: 'apiKey', in: 'header', name: 'X-API-Key' }
 
@@ -553,9 +611,15 @@ export const getMeRoute = createRoute({
   security: [{ hkey: [] }],
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getMeRouteHandler: RouteHandler<typeof getMeRoute> = async (c) => {
   if (!c.req.header('X-API-Key')) {
     return c.json({ message: 'Unauthorized' }, 401)
+  }
+  const prefer = resolvePrefer(c.req, { '200': [], '401': [] }, '200')
+  if (prefer.key === '401') {
+    return c.body(null, 401)
   }
   return c.json({ id: faker.number.int({ min: 1, max: 99999 }) }, 200)
 }
@@ -602,6 +666,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const BasicAuthSecurityScheme = { type: 'http', scheme: 'basic' }
 
@@ -621,9 +687,15 @@ export const getMeRoute = createRoute({
   security: [{ basicAuth: [] }],
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getMeRouteHandler: RouteHandler<typeof getMeRoute> = async (c) => {
   if (!c.req.header('Authorization')) {
     return c.json({ message: 'Unauthorized' }, 401)
+  }
+  const prefer = resolvePrefer(c.req, { '200': [], '401': [] }, '200')
+  if (prefer.key === '401') {
+    return c.body(null, 401)
   }
   return c.json({ id: faker.number.int({ min: 1, max: 99999 }) }, 200)
 }
@@ -670,6 +742,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const OauthSecurityScheme = { type: 'oauth2', flows: {} }
 
@@ -689,9 +763,15 @@ export const getMeRoute = createRoute({
   security: [{ oauth: [] }],
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getMeRouteHandler: RouteHandler<typeof getMeRoute> = async (c) => {
   if (!c.req.header('Authorization')) {
     return c.json({ message: 'Unauthorized' }, 401)
+  }
+  const prefer = resolvePrefer(c.req, { '200': [], '401': [] }, '200')
+  if (prefer.key === '401') {
+    return c.body(null, 401)
   }
   return c.json({ id: faker.number.int({ min: 1, max: 99999 }) }, 200)
 }
@@ -737,6 +817,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const BearerAuthSecurityScheme = { type: 'http', scheme: 'bearer' }
 
@@ -755,7 +837,10 @@ export const getMeRoute = createRoute({
   security: [{ bearerAuth: [] }],
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getMeRouteHandler: RouteHandler<typeof getMeRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json({ id: faker.number.int({ min: 1, max: 99999 }) }, 200)
 }
 
@@ -790,6 +875,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const getGreetRoute = createRoute({
   method: 'get',
@@ -798,7 +885,10 @@ export const getGreetRoute = createRoute({
   responses: { 200: { description: 'OK', content: { 'text/plain': { schema: z.string() } } } },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getGreetRouteHandler: RouteHandler<typeof getGreetRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.text(faker.string.alpha({ length: { min: 5, max: 20 } }), 200)
 }
 
@@ -846,6 +936,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 type NodeType = { id?: number; next?: NodeType }
 
@@ -869,7 +961,10 @@ function mockNode(): any {
   }
 }
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getTreeRouteHandler: RouteHandler<typeof getTreeRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json(mockNode(), 200)
 }
 
@@ -900,6 +995,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const postUploadRoute = createRoute({
   method: 'post',
@@ -909,7 +1006,10 @@ export const postUploadRoute = createRoute({
   responses: { 200: { description: 'OK' } },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const postUploadRouteHandler: RouteHandler<typeof postUploadRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.body(null, 200)
 }
 
@@ -937,6 +1037,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const getXRoute = createRoute({
   method: 'get',
@@ -954,7 +1056,10 @@ export const getXRoute = createRoute({
   responses: { 200: { description: 'OK' } },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getXRouteHandler: RouteHandler<typeof getXRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.body(null, 200)
 }
 
@@ -1000,6 +1105,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const AkSecurityScheme = { type: 'apiKey', in: 'header' }
 
@@ -1017,9 +1124,15 @@ export const getMeRoute = createRoute({
   security: [{ ak: [] }],
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getMeRouteHandler: RouteHandler<typeof getMeRoute> = async (c) => {
   if (!c.req.header('X-API-Key')) {
     return c.json({ message: 'Unauthorized' }, 401)
+  }
+  const prefer = resolvePrefer(c.req, { '200': [], '401': [] }, '200')
+  if (prefer.key === '401') {
+    return c.body(null, 401)
   }
   return c.json(
     { id: faker.helpers.arrayElement([faker.number.int({ min: 1, max: 99999 }), undefined]) },
@@ -1065,6 +1178,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const BearerSecurityScheme = { type: 'http', scheme: 'bearer' }
 
@@ -1081,9 +1196,15 @@ export const getMeRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getMeRouteHandler: RouteHandler<typeof getMeRoute> = async (c) => {
   if (!c.req.header('Authorization')) {
     return c.json({ message: 'Unauthorized' }, 401)
+  }
+  const prefer = resolvePrefer(c.req, { '200': [], '401': [] }, '200')
+  if (prefer.key === '401') {
+    return c.body(null, 401)
   }
   return c.json(
     { id: faker.helpers.arrayElement([faker.number.int({ min: 1, max: 99999 }), undefined]) },
@@ -1142,6 +1263,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const ChildSchema: z.ZodType<ChildType> = z
   .lazy(() => z.object({ id: z.int().exactOptional(), parent: ParentSchema.exactOptional() }))
@@ -1178,7 +1301,10 @@ function mockParent(): any {
   }
 }
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getParentRouteHandler: RouteHandler<typeof getParentRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json(mockParent(), 200)
 }
 
@@ -1216,6 +1342,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const UserIdSchema = z.string().brand<'UserId'>().openapi('UserId')
 
@@ -1232,7 +1360,10 @@ function mockUserId() {
   return faker.string.alpha({ length: { min: 5, max: 20 } }) as z.infer<typeof UserIdSchema>
 }
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getUserRouteHandler: RouteHandler<typeof getUserRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json(mockUserId(), 200)
 }
 
@@ -1271,6 +1402,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const postItemsRoute = createRoute({
   method: 'post',
@@ -1284,7 +1417,22 @@ export const postItemsRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const postItemsRouteHandler: RouteHandler<typeof postItemsRoute> = async (c) => {
+  const prefer = resolvePrefer(c.req, { default: [] }, 'default')
+  if (prefer.key === 'default') {
+    return preferResponse(
+      Number(prefer.code ?? 200),
+      JSON.stringify({
+        id: faker.helpers.arrayElement([
+          faker.string.alpha({ length: { min: 5, max: 20 } }),
+          undefined,
+        ]),
+      }),
+      'application/json',
+    )
+  }
   return c.json(
     {
       id: faker.helpers.arrayElement([
@@ -1325,6 +1473,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const getPingRoute = createRoute({
   method: 'get',
@@ -1333,7 +1483,17 @@ export const getPingRoute = createRoute({
   responses: { '2XX': { description: 'ok', content: { 'text/plain': { schema: z.string() } } } },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getPingRouteHandler: RouteHandler<typeof getPingRoute> = async (c) => {
+  const prefer = resolvePrefer(c.req, { '2XX': [] }, '2XX')
+  if (prefer.key === '2XX') {
+    return preferResponse(
+      Number(prefer.code ?? 200),
+      String(faker.string.alpha({ length: { min: 5, max: 20 } })),
+      'text/plain',
+    )
+  }
   return c.text(faker.string.alpha({ length: { min: 5, max: 20 } }), 200)
 }
 
@@ -1358,6 +1518,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const postNoopRoute = createRoute({
   method: 'post',
@@ -1366,7 +1528,13 @@ export const postNoopRoute = createRoute({
   responses: { default: { description: 'ok' } },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const postNoopRouteHandler: RouteHandler<typeof postNoopRoute> = async (c) => {
+  const prefer = resolvePrefer(c.req, { default: [] }, 'default')
+  if (prefer.key === 'default') {
+    return preferResponse(Number(prefer.code ?? 200), null)
+  }
   return c.body(null, 200)
 }
 
@@ -1391,6 +1559,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const postCreateRoute = createRoute({
   method: 'post',
@@ -1399,7 +1569,10 @@ export const postCreateRoute = createRoute({
   responses: { 201: { description: 'created' } },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const postCreateRouteHandler: RouteHandler<typeof postCreateRoute> = async (c) => {
+  resolvePrefer(c.req, { '201': [] }, '201')
   return c.body(null, 201)
 }
 
@@ -1444,6 +1617,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const getBothRoute = createRoute({
   method: 'get',
@@ -1461,7 +1636,22 @@ export const getBothRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getBothRouteHandler: RouteHandler<typeof getBothRoute> = async (c) => {
+  const prefer = resolvePrefer(c.req, { '200': [], default: [] }, '200')
+  if (prefer.key === 'default') {
+    return preferResponse(
+      Number(prefer.code ?? 200),
+      JSON.stringify({
+        b: faker.helpers.arrayElement([
+          faker.string.alpha({ length: { min: 5, max: 20 } }),
+          undefined,
+        ]),
+      }),
+      'application/json',
+    )
+  }
   return c.json(
     {
       a: faker.helpers.arrayElement([
@@ -1521,6 +1711,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const UserIdSchema = z.string().brand<'userId'>().openapi('UserId')
 
@@ -1552,7 +1744,10 @@ function mockNotification() {
   return { id: mockuserId(), type: mocknotificationType() }
 }
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getNRouteHandler: RouteHandler<typeof getNRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json(mockNotification(), 200)
 }
 
@@ -1601,6 +1796,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const UserSchema = z
   .object({ id: z.int(), name: z.string() })
@@ -1619,7 +1816,10 @@ export const getMeRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getMeRouteHandler: RouteHandler<typeof getMeRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json({ id: 1, name: 'Alice' } as z.infer<typeof UserSchema>, 200)
 }
 
@@ -1669,6 +1869,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const UserSchema = z
   .object({ id: z.int(), name: z.string() })
@@ -1695,7 +1897,13 @@ export const getMeRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getMeRouteHandler: RouteHandler<typeof getMeRoute> = async (c) => {
+  const prefer = resolvePrefer(c.req, { '200': ['first', 'second'] }, '200')
+  if (prefer.key === '200' && prefer.example === 'second') {
+    return c.json({ id: 2, name: 'Bob' } as z.infer<typeof UserSchema>, 200)
+  }
   return c.json({ id: 1, name: 'Alice' } as z.infer<typeof UserSchema>, 200)
 }
 
@@ -1743,6 +1951,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const UserSchema = z
   .object({ id: z.int(), name: z.string() })
@@ -1765,7 +1975,10 @@ export const getMeRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getMeRouteHandler: RouteHandler<typeof getMeRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': ['default'] }, '200')
   return c.json({ id: 1, name: 'Alice' } as z.infer<typeof UserSchema>, 200)
 }
 
@@ -1803,6 +2016,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const getVRoute = createRoute({
   method: 'get',
@@ -1821,7 +2036,10 @@ export const getVRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getVRouteHandler: RouteHandler<typeof getVRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json({ ok: true }, 200)
 }
 
@@ -1869,6 +2087,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const PostSchema = z
   .object({ id: z.int() })
@@ -1907,7 +2127,10 @@ export const getPostsRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getPostsRouteHandler: RouteHandler<typeof getPostsRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json([{ id: 1 }, { id: 2 }], 200)
 }
 
@@ -1956,6 +2179,8 @@ export default app
       expect(await format(spec, '/'))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const PostSchema = z
   .object({ id: z.int() })
@@ -1993,7 +2218,10 @@ function mockPost() {
   return { id: faker.number.int({ min: 1, max: 99999 }) }
 }
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getPostsRouteHandler: RouteHandler<typeof getPostsRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json(
     Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, () => mockPost()),
     200,
@@ -2012,9 +2240,11 @@ export default app
   describe('locale', () => {
     it('imports the localized faker entry when locale is set', async () => {
       const result = await runGenerator(fmt(makeMock(minimalOpenAPI, '/', { locale: 'ja' })))
-      expect(result)
+      expect(withoutPreferHelpers(result))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker/locale/ja'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const getHealthRoute = createRoute({
   method: 'get',
@@ -2028,7 +2258,10 @@ export const getHealthRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getHealthRouteHandler: RouteHandler<typeof getHealthRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json(
     {
       status: faker.helpers.arrayElement([
@@ -2052,9 +2285,11 @@ export default app
   describe('delay', () => {
     it('emits a delay middleware when delay is a number', async () => {
       const result = await runGenerator(fmt(makeMock(minimalOpenAPI, '/', { delay: 1000 })))
-      expect(result)
+      expect(withoutPreferHelpers(result))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const getHealthRoute = createRoute({
   method: 'get',
@@ -2068,7 +2303,10 @@ export const getHealthRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getHealthRouteHandler: RouteHandler<typeof getHealthRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json(
     {
       status: faker.helpers.arrayElement([
@@ -2097,9 +2335,11 @@ export default app
       const result = await runGenerator(
         fmt(makeMock(minimalOpenAPI, '/', { delay: { min: 100, max: 500 } })),
       )
-      expect(result)
+      expect(withoutPreferHelpers(result))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const getHealthRoute = createRoute({
   method: 'get',
@@ -2113,7 +2353,10 @@ export const getHealthRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getHealthRouteHandler: RouteHandler<typeof getHealthRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json(
     {
       status: faker.helpers.arrayElement([
@@ -2171,9 +2414,11 @@ export default app
 
     it('returns the spec example verbatim by default', async () => {
       const result = await runGenerator(fmt(makeMock(exampleOpenAPI, '/')))
-      expect(result)
+      expect(withoutPreferHelpers(result))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const getPingRoute = createRoute({
   method: 'get',
@@ -2192,7 +2437,10 @@ export const getPingRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getPingRouteHandler: RouteHandler<typeof getPingRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json({ msg: 'pong' }, 200)
 }
 
@@ -2206,9 +2454,11 @@ export default app
 
     it('fakes the response instead of the example when useExamples is false', async () => {
       const result = await runGenerator(fmt(makeMock(exampleOpenAPI, '/', { useExamples: false })))
-      expect(result)
+      expect(withoutPreferHelpers(result))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const getPingRoute = createRoute({
   method: 'get',
@@ -2227,7 +2477,10 @@ export const getPingRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getPingRouteHandler: RouteHandler<typeof getPingRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json(
     {
       msg: faker.helpers.arrayElement([
@@ -2276,9 +2529,11 @@ export default app
         },
       } as OpenAPI
       const result = await runGenerator(fmt(makeMock(spec, '/')))
-      expect(result)
+      expect(withoutPreferHelpers(result))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 if (!('toJSON' in BigInt.prototype)) {
   Object.defineProperty(BigInt.prototype, 'toJSON', {
@@ -2304,7 +2559,10 @@ export const getBigRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getBigRouteHandler: RouteHandler<typeof getBigRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json({ id: faker.number.bigInt({ min: 0n, max: 9007199254740991n }) }, 200)
 }
 
@@ -2346,9 +2604,11 @@ export default app
         },
       } as OpenAPI
       const result = await runGenerator(fmt(makeMock(spec, '/')))
-      expect(result)
+      expect(withoutPreferHelpers(result))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 if (!('toJSON' in BigInt.prototype)) {
   Object.defineProperty(BigInt.prototype, 'toJSON', {
@@ -2378,7 +2638,10 @@ function mockCounter() {
   return { total: faker.number.bigInt({ min: 0n, max: 9007199254740991n }) }
 }
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getCounterRouteHandler: RouteHandler<typeof getCounterRoute> = async (c) => {
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json(mockCounter(), 200)
 }
 
@@ -2438,9 +2701,11 @@ export default app
         },
       } as OpenAPI
       const result = await runGenerator(fmt(makeMock(spec, '/')))
-      expect(result)
+      expect(withoutPreferHelpers(result))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const getItemsIdRoute = createRoute({
   method: 'get',
@@ -2478,8 +2743,14 @@ export const getItemsIdRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getItemsIdRouteHandler: RouteHandler<typeof getItemsIdRoute> = async (c) => {
-  if (c.req.param('id') === '00000000-0000-0000-0000-000000000000') {
+  const prefer = resolvePrefer(c.req, { '200': [], '404': [] }, '200')
+  if (prefer.key === '404') {
+    return c.json({ error: faker.string.alpha({ length: { min: 5, max: 20 } }) }, 404)
+  }
+  if (prefer.key === undefined && c.req.param('id') === '00000000-0000-0000-0000-000000000000') {
     return c.json({ error: faker.string.alpha({ length: { min: 5, max: 20 } }) }, 404)
   }
   return c.json({ id: faker.string.uuid() }, 200)
@@ -2497,9 +2768,11 @@ export default app
   describe('seed', () => {
     it('re-seeds faker and pins its reference date at the start of every handler', async () => {
       const result = await runGenerator(fmt(makeMock(minimalOpenAPI, '/', { seed: 42 })))
-      expect(result)
+      expect(withoutPreferHelpers(result))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const getHealthRoute = createRoute({
   method: 'get',
@@ -2513,9 +2786,12 @@ export const getHealthRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getHealthRouteHandler: RouteHandler<typeof getHealthRoute> = async (c) => {
   faker.seed(42)
   faker.setDefaultRefDate('2025-01-01T00:00:00.000Z')
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json(
     {
       status: faker.helpers.arrayElement([
@@ -2537,9 +2813,11 @@ export default app
 
     it('passes an array seed through', async () => {
       const result = await runGenerator(fmt(makeMock(minimalOpenAPI, '/', { seed: [1, 2] })))
-      expect(result)
+      expect(withoutPreferHelpers(result))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 export const getHealthRoute = createRoute({
   method: 'get',
@@ -2553,9 +2831,12 @@ export const getHealthRoute = createRoute({
   },
 })
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getHealthRouteHandler: RouteHandler<typeof getHealthRoute> = async (c) => {
   faker.seed([1, 2])
   faker.setDefaultRefDate('2025-01-01T00:00:00.000Z')
+  resolvePrefer(c.req, { '200': [] }, '200')
   return c.json(
     {
       status: faker.helpers.arrayElement([
@@ -2589,7 +2870,7 @@ export default app
         '/',
         { seed: 42 },
       )
-      expect(result).not.toContain('faker.seed(')
+      expect(withoutPreferHelpers(result)).not.toContain('faker.seed(')
     })
   })
 
@@ -2635,9 +2916,11 @@ export default app
 
     it('sanitizes a hyphenated schema name, quotes keys and escapes auth / param names', async () => {
       const result = await runGenerator(fmt(makeMock(edgeOpenAPI, '/')))
-      expect(result)
+      expect(withoutPreferHelpers(result))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const UserProfileSchema = z
   .object({
@@ -2676,13 +2959,22 @@ function mockUserProfile() {
   }
 }
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getProfilesProfileIdRouteHandler: RouteHandler<typeof getProfilesProfileIdRoute> = async (
   c,
 ) => {
   if (!c.req.header("X-Key'); evil(); ('")) {
     return c.json({ message: 'Unauthorized' }, 401)
   }
-  if (c.req.param('profile-id') === '__non_existent__') {
+  const prefer = resolvePrefer(c.req, { '200': [], '401': [], '404': [] }, '200')
+  if (prefer.key === '401') {
+    return c.body(null, 401)
+  }
+  if (prefer.key === '404') {
+    return c.body(null, 404)
+  }
+  if (prefer.key === undefined && c.req.param('profile-id') === '__non_existent__') {
     return c.body(null, 404)
   }
   return c.json(mockUserProfile(), 200)
@@ -2698,9 +2990,11 @@ export default app
 
     it("uses a property's scalar example when useExamples is 'all'", async () => {
       const result = await runGenerator(fmt(makeMock(edgeOpenAPI, '/', { useExamples: 'all' })))
-      expect(result)
+      expect(withoutPreferHelpers(result))
         .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
 import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const UserProfileSchema = z
   .object({
@@ -2736,13 +3030,22 @@ function mockUserProfile() {
   return { 'first-name': faker.person.firstName(), role: 'admin' as const }
 }
 
+/* resolvePrefer, preferResponse, preferProblem */
+
 const getProfilesProfileIdRouteHandler: RouteHandler<typeof getProfilesProfileIdRoute> = async (
   c,
 ) => {
   if (!c.req.header("X-Key'); evil(); ('")) {
     return c.json({ message: 'Unauthorized' }, 401)
   }
-  if (c.req.param('profile-id') === '__non_existent__') {
+  const prefer = resolvePrefer(c.req, { '200': [], '401': [], '404': [] }, '200')
+  if (prefer.key === '401') {
+    return c.body(null, 401)
+  }
+  if (prefer.key === '404') {
+    return c.body(null, 404)
+  }
+  if (prefer.key === undefined && c.req.param('profile-id') === '__non_existent__') {
     return c.body(null, 404)
   }
   return c.json(mockUserProfile(), 200)
@@ -2751,6 +3054,238 @@ const getProfilesProfileIdRouteHandler: RouteHandler<typeof getProfilesProfileId
 const app = new OpenAPIHono()
 
 export const api = app.openapi(getProfilesProfileIdRoute, getProfilesProfileIdRouteHandler)
+
+export default app
+`)
+    })
+  })
+
+  describe('Prefer (Prism-compatible response selection)', () => {
+    it('emits the resolvePrefer / preferResponse / preferProblem helpers once', async () => {
+      const result = await runGenerator(fmt(makeMock(minimalOpenAPI, '/')))
+      const helpers = result.match(
+        /\/\/ Reads Prism's[\s\S]*?\nfunction preferProblem\([\s\S]*?\n\}\n/gu,
+      )
+      expect(helpers?.length).toBe(1)
+      expect(helpers?.[0])
+        .toBe(`// Reads Prism's \`Prefer: code=<status>, example=<name>\` header (or the \`__code\` /
+// \`__example\` query) and resolves it against the responses the route declares:
+// the exact status, then its \`NXX\` range, then \`default\`. Without a code the
+// example is looked up in the success response. Anything the route does not
+// declare answers 500 problem+json, as Prism does.
+function resolvePrefer(
+  req: { header(name: string): string | undefined; query(name: string): string | undefined },
+  responses: { readonly [key: string]: readonly string[] },
+  success: string,
+) {
+  let code = req.query('__code')
+  let example = req.query('__example')
+  for (const [, name = '', quoted, bare] of (req.header('Prefer') ?? '').matchAll(
+    /([A-Za-z]+)\\s*=\\s*(?:"([^"]*)"|([^\\s,;]*))/gu,
+  )) {
+    if (name.toLowerCase() === 'code') code ??= quoted ?? bare
+    if (name.toLowerCase() === 'example') example ??= quoted ?? bare
+  }
+  if (code === undefined && example === undefined) return {}
+  if (code !== undefined && !/^[2-5]\\d\\d$/u.test(code)) {
+    preferProblem(\`Prefer code=\${code} is not a status code between 200 and 599.\`)
+  }
+  const key =
+    code === undefined
+      ? success
+      : [code, \`\${code.slice(0, 1)}XX\`, 'default'].find((k) => Object.hasOwn(responses, k))
+  if (key === undefined) preferProblem(\`No \${code} response is declared for this operation.\`)
+  if (example !== undefined && !responses[key]?.includes(example)) {
+    preferProblem(\`No example named "\${example}" is declared for the \${key} response.\`)
+  }
+  return { key, code, example }
+}
+
+// Answers with a status the route's types cannot name (a \`4XX\`/\`default\` response
+// picked at runtime); Hono's error handler sends \`res\` with that status.
+function preferResponse(status: number, body: string | null, contentType?: string): never {
+  throw new HTTPException(status as ContentfulStatusCode, {
+    res: new Response(body, contentType ? { headers: { 'Content-Type': contentType } } : {}),
+  })
+}
+
+function preferProblem(detail: string): never {
+  return preferResponse(
+    500,
+    JSON.stringify({
+      type: 'about:blank',
+      title: 'Mock response unavailable',
+      status: 500,
+      detail,
+    }),
+    'application/problem+json',
+  )
+}
+`)
+    })
+
+    it('branches on named examples, problem+json, a 4XX range, default and no-content responses', async () => {
+      const spec = {
+        openapi: '3.1.0',
+        info: { title: 'T', version: '1' },
+        paths: {
+          '/orders/{orderId}': {
+            get: {
+              operationId: 'getOrder',
+              parameters: [
+                { name: 'orderId', in: 'path', required: true, schema: { type: 'string' } },
+              ],
+              responses: {
+                '200': {
+                  description: 'The order',
+                  content: {
+                    'application/json': {
+                      schema: { $ref: '#/components/schemas/Order' },
+                      examples: {
+                        shipped: { $ref: '#/components/examples/ShippedOrder' },
+                        pending: { value: { id: 'o-2' } },
+                        external: { externalValue: 'https://example.com/order.json' },
+                      },
+                    },
+                  },
+                },
+                '404': {
+                  description: 'No such order',
+                  content: {
+                    'application/problem+json': {
+                      schema: { $ref: '#/components/schemas/Problem' },
+                    },
+                  },
+                },
+                '4xx': {
+                  description: 'Client error',
+                  content: { 'text/plain': { schema: { type: 'string' } } },
+                },
+                '503': { description: 'Maintenance' },
+                default: {
+                  description: 'Unexpected error',
+                  content: {
+                    'application/json': { schema: { $ref: '#/components/schemas/Problem' } },
+                  },
+                },
+              },
+            },
+          },
+        },
+        components: {
+          examples: { ShippedOrder: { value: { id: 'o-1' } } },
+          schemas: {
+            Order: { type: 'object', required: ['id'], properties: { id: { type: 'string' } } },
+            Problem: {
+              type: 'object',
+              required: ['title'],
+              properties: { title: { type: 'string' } },
+            },
+          },
+        },
+      } as OpenAPI
+      expect(await format(spec, '/'))
+        .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
+import { faker } from '@faker-js/faker'
+import { HTTPException } from 'hono/http-exception'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
+
+const OrderSchema = z
+  .object({ id: z.string() })
+  .openapi({ required: ['id'] })
+  .openapi('Order')
+
+const ProblemSchema = z
+  .object({ title: z.string() })
+  .openapi({ required: ['title'] })
+  .openapi('Problem')
+
+const ShippedOrderExample = { value: { id: 'o-1' } }
+
+export const getOrdersOrderIdRoute = createRoute({
+  method: 'get',
+  path: '/orders/{orderId}',
+  operationId: 'getOrder',
+  request: {
+    params: z.object({
+      orderId: z
+        .string()
+        .openapi({
+          param: { name: 'orderId', in: 'path', required: true, schema: { type: 'string' } },
+        }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'The order',
+      content: {
+        'application/json': {
+          schema: OrderSchema,
+          examples: {
+            shipped: ShippedOrderExample,
+            pending: { value: { id: 'o-2' } },
+            external: { externalValue: 'https://example.com/order.json' },
+          },
+        },
+      },
+    },
+    404: {
+      description: 'No such order',
+      content: { 'application/problem+json': { schema: ProblemSchema } },
+    },
+    503: { description: 'Maintenance' },
+    '4xx': { description: 'Client error', content: { 'text/plain': { schema: z.string() } } },
+    default: {
+      description: 'Unexpected error',
+      content: { 'application/json': { schema: ProblemSchema } },
+    },
+  },
+})
+
+function mockProblem() {
+  return { title: faker.lorem.sentence() }
+}
+
+/* resolvePrefer, preferResponse, preferProblem */
+
+const getOrdersOrderIdRouteHandler: RouteHandler<typeof getOrdersOrderIdRoute> = async (c) => {
+  const prefer = resolvePrefer(
+    c.req,
+    { '200': ['shipped', 'pending'], '404': [], '503': [], '4XX': [], default: [] },
+    '200',
+  )
+  if (prefer.key === '200' && prefer.example === 'pending') {
+    return c.json({ id: 'o-2' } as z.infer<typeof OrderSchema>, 200)
+  }
+  if (prefer.key === '404') {
+    return c.json(mockProblem(), 404, { 'Content-Type': 'application/problem+json' })
+  }
+  if (prefer.key === '503') {
+    return c.body(null, 503)
+  }
+  if (prefer.key === '4XX') {
+    return preferResponse(
+      Number(prefer.code ?? 400),
+      String(faker.string.alpha({ length: { min: 5, max: 20 } })),
+      'text/plain',
+    )
+  }
+  if (prefer.key === 'default') {
+    return preferResponse(
+      Number(prefer.code ?? 200),
+      JSON.stringify(mockProblem()),
+      'application/json',
+    )
+  }
+  if (prefer.key === undefined && c.req.param('orderId') === '__non_existent__') {
+    return c.json(mockProblem(), 404, { 'Content-Type': 'application/problem+json' })
+  }
+  return c.json({ id: 'o-1' } as z.infer<typeof OrderSchema>, 200)
+}
+
+const app = new OpenAPIHono()
+
+export const api = app.openapi(getOrdersOrderIdRoute, getOrdersOrderIdRouteHandler)
 
 export default app
 `)

--- a/packages/hono-takibi/src/generator/mock/index.test.ts
+++ b/packages/hono-takibi/src/generator/mock/index.test.ts
@@ -2493,4 +2493,267 @@ export default app
 `)
     })
   })
+
+  describe('seed', () => {
+    it('re-seeds faker and pins its reference date at the start of every handler', async () => {
+      const result = await runGenerator(fmt(makeMock(minimalOpenAPI, '/', { seed: 42 })))
+      expect(result)
+        .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
+import { faker } from '@faker-js/faker'
+
+export const getHealthRoute = createRoute({
+  method: 'get',
+  path: '/health',
+  operationId: 'getHealth',
+  responses: {
+    200: {
+      description: 'OK',
+      content: { 'application/json': { schema: z.object({ status: z.string().exactOptional() }) } },
+    },
+  },
+})
+
+const getHealthRouteHandler: RouteHandler<typeof getHealthRoute> = async (c) => {
+  faker.seed(42)
+  faker.setDefaultRefDate('2025-01-01T00:00:00.000Z')
+  return c.json(
+    {
+      status: faker.helpers.arrayElement([
+        faker.helpers.arrayElement(['active', 'inactive', 'pending']),
+        undefined,
+      ]),
+    },
+    200,
+  )
+}
+
+const app = new OpenAPIHono()
+
+export const api = app.openapi(getHealthRoute, getHealthRouteHandler)
+
+export default app
+`)
+    })
+
+    it('passes an array seed through', async () => {
+      const result = await runGenerator(fmt(makeMock(minimalOpenAPI, '/', { seed: [1, 2] })))
+      expect(result)
+        .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
+import { faker } from '@faker-js/faker'
+
+export const getHealthRoute = createRoute({
+  method: 'get',
+  path: '/health',
+  operationId: 'getHealth',
+  responses: {
+    200: {
+      description: 'OK',
+      content: { 'application/json': { schema: z.object({ status: z.string().exactOptional() }) } },
+    },
+  },
+})
+
+const getHealthRouteHandler: RouteHandler<typeof getHealthRoute> = async (c) => {
+  faker.seed([1, 2])
+  faker.setDefaultRefDate('2025-01-01T00:00:00.000Z')
+  return c.json(
+    {
+      status: faker.helpers.arrayElement([
+        faker.helpers.arrayElement(['active', 'inactive', 'pending']),
+        undefined,
+      ]),
+    },
+    200,
+  )
+}
+
+const app = new OpenAPIHono()
+
+export const api = app.openapi(getHealthRoute, getHealthRouteHandler)
+
+export default app
+`)
+    })
+
+    it('does not seed a handler that never calls faker', () => {
+      const result = makeMock(
+        {
+          openapi: '3.1.0',
+          info: { title: 'T', version: '1' },
+          paths: {
+            '/ping': {
+              delete: { operationId: 'deletePing', responses: { '204': { description: 'gone' } } },
+            },
+          },
+        } as OpenAPI,
+        '/',
+        { seed: 42 },
+      )
+      expect(result).not.toContain('faker.seed(')
+    })
+  })
+
+  describe('document-supplied names', () => {
+    const edgeOpenAPI = {
+      openapi: '3.1.0',
+      info: { title: 'T', version: '1' },
+      security: [{ Key: [] }],
+      paths: {
+        '/profiles/{profile-id}': {
+          get: {
+            operationId: 'getProfile',
+            parameters: [
+              { name: 'profile-id', in: 'path', required: true, schema: { type: 'string' } },
+            ],
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': { schema: { $ref: '#/components/schemas/User-Profile' } },
+                },
+              },
+              '401': { description: 'no' },
+              '404': { description: 'none' },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: { Key: { type: 'apiKey', in: 'header', name: "X-Key'); evil(); ('" } },
+        schemas: {
+          'User-Profile': {
+            type: 'object',
+            required: ['first-name', 'role'],
+            properties: {
+              'first-name': { type: 'string' },
+              role: { type: 'string', enum: ['admin', 'member'], example: 'admin' },
+            },
+          },
+        },
+      },
+    } as OpenAPI
+
+    it('sanitizes a hyphenated schema name, quotes keys and escapes auth / param names', async () => {
+      const result = await runGenerator(fmt(makeMock(edgeOpenAPI, '/')))
+      expect(result)
+        .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
+import { faker } from '@faker-js/faker'
+
+const UserProfileSchema = z
+  .object({
+    'first-name': z.string(),
+    role: z.enum(['admin', 'member']).openapi({ example: 'admin' }),
+  })
+  .openapi({ required: ['first-name', 'role'] })
+  .openapi('UserProfile')
+
+const KeySecurityScheme = { type: 'apiKey', in: 'header', name: "X-Key'); evil(); ('" }
+
+export const getProfilesProfileIdRoute = createRoute({
+  method: 'get',
+  path: '/profiles/{profile-id}',
+  operationId: 'getProfile',
+  request: {
+    params: z.object({
+      'profile-id': z
+        .string()
+        .openapi({
+          param: { name: 'profile-id', in: 'path', required: true, schema: { type: 'string' } },
+        }),
+    }),
+  },
+  responses: {
+    200: { description: 'OK', content: { 'application/json': { schema: UserProfileSchema } } },
+    401: { description: 'no' },
+    404: { description: 'none' },
+  },
+})
+
+function mockUserProfile() {
+  return {
+    'first-name': faker.person.firstName(),
+    role: faker.helpers.arrayElement(['admin', 'member'] as const),
+  }
+}
+
+const getProfilesProfileIdRouteHandler: RouteHandler<typeof getProfilesProfileIdRoute> = async (
+  c,
+) => {
+  if (!c.req.header("X-Key'); evil(); ('")) {
+    return c.json({ message: 'Unauthorized' }, 401)
+  }
+  if (c.req.param('profile-id') === '__non_existent__') {
+    return c.body(null, 404)
+  }
+  return c.json(mockUserProfile(), 200)
+}
+
+const app = new OpenAPIHono()
+
+export const api = app.openapi(getProfilesProfileIdRoute, getProfilesProfileIdRouteHandler)
+
+export default app
+`)
+    })
+
+    it("uses a property's scalar example when useExamples is 'all'", async () => {
+      const result = await runGenerator(fmt(makeMock(edgeOpenAPI, '/', { useExamples: 'all' })))
+      expect(result)
+        .toBe(`import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
+import { faker } from '@faker-js/faker'
+
+const UserProfileSchema = z
+  .object({
+    'first-name': z.string(),
+    role: z.enum(['admin', 'member']).openapi({ example: 'admin' }),
+  })
+  .openapi({ required: ['first-name', 'role'] })
+  .openapi('UserProfile')
+
+const KeySecurityScheme = { type: 'apiKey', in: 'header', name: "X-Key'); evil(); ('" }
+
+export const getProfilesProfileIdRoute = createRoute({
+  method: 'get',
+  path: '/profiles/{profile-id}',
+  operationId: 'getProfile',
+  request: {
+    params: z.object({
+      'profile-id': z
+        .string()
+        .openapi({
+          param: { name: 'profile-id', in: 'path', required: true, schema: { type: 'string' } },
+        }),
+    }),
+  },
+  responses: {
+    200: { description: 'OK', content: { 'application/json': { schema: UserProfileSchema } } },
+    401: { description: 'no' },
+    404: { description: 'none' },
+  },
+})
+
+function mockUserProfile() {
+  return { 'first-name': faker.person.firstName(), role: 'admin' as const }
+}
+
+const getProfilesProfileIdRouteHandler: RouteHandler<typeof getProfilesProfileIdRoute> = async (
+  c,
+) => {
+  if (!c.req.header("X-Key'); evil(); ('")) {
+    return c.json({ message: 'Unauthorized' }, 401)
+  }
+  if (c.req.param('profile-id') === '__non_existent__') {
+    return c.body(null, 404)
+  }
+  return c.json(mockUserProfile(), 200)
+}
+
+const app = new OpenAPIHono()
+
+export const api = app.openapi(getProfilesProfileIdRoute, getProfilesProfileIdRouteHandler)
+
+export default app
+`)
+    })
+  })
 })

--- a/packages/hono-takibi/src/generator/mock/index.ts
+++ b/packages/hono-takibi/src/generator/mock/index.ts
@@ -9,7 +9,7 @@ import {
   isSchemaObject,
   isSecurityScheme,
 } from '../../guard/index.js'
-import { getNonExistentValue, schemaToFaker } from '../../helper/faker.js'
+import { getNonExistentValue, mockFunctionName, schemaToFaker } from '../../helper/faker.js'
 import type {
   Components,
   Media,
@@ -21,6 +21,7 @@ import type {
 import {
   cyclicNodes,
   ensureSuffix,
+  makeStringLiteral,
   methodPath,
   statusCodeToNumber,
   toIdentifierPascalCase,
@@ -158,7 +159,7 @@ function makeMockFunction(
   schema: Schema,
   schemas: { readonly [k: string]: Schema },
   isCircular: boolean,
-  fakerOptions: { readonly arrayMin?: number; readonly arrayMax?: number },
+  fakerOptions: FakerOptions,
 ) {
   const mockBody = schemaToFaker(schema, undefined, { schemas, ...fakerOptions })
   const returnType = isCircular ? ': any' : ''
@@ -172,10 +173,9 @@ function makeMockFunction(
   // The cast target must match the emitted const name, which `helper/schema.ts`
   // derives as `toIdentifierPascalCase(ensureSuffix(name, 'Schema'))` — using
   // the raw name here would mis-case it (e.g. `userIdSchema` vs `UserIdSchema`).
-  const sanitized = name.replaceAll('.', '')
   const schemaConst = toIdentifierPascalCase(ensureSuffix(name, 'Schema'))
   const body = schema['x-brand'] ? `${mockBody} as z.infer<typeof ${schemaConst}>` : mockBody
-  return `function mock${sanitized}()${returnType}{return ${body}}` as const
+  return `function ${mockFunctionName(name)}()${returnType}{return ${body}}` as const
 }
 
 function extractSecurityInfo(
@@ -321,12 +321,13 @@ function makeAuthCheck(
       return [`c.req.header('Authorization')`]
     }
     if (sec.type === 'apiKey') {
-      if (sec.in === 'header') return [`c.req.header('${sec.name}')`]
-      if (sec.in === 'query') return [`c.req.query('${sec.name}')`]
+      // `name` comes from the document, so it is emitted as an escaped literal.
+      if (sec.in === 'header') return [`c.req.header(${makeStringLiteral(sec.name)})`]
+      if (sec.in === 'query') return [`c.req.query(${makeStringLiteral(sec.name)})`]
       // Hono's request object does not expose a `.cookie()` accessor; cookies
       // must come from the `hono/cookie` helper. Caller is responsible for
       // emitting the matching `import { getCookie } from 'hono/cookie'`.
-      if (sec.in === 'cookie') return [`getCookie(c, '${sec.name}')`]
+      if (sec.in === 'cookie') return [`getCookie(c, ${makeStringLiteral(sec.name)})`]
     }
     return []
   })
@@ -357,7 +358,7 @@ function makeHandlerBody(args: {
   readonly jsonSchema: Schema | undefined
   readonly textSchema: Schema | undefined
   readonly schemas: { readonly [k: string]: Schema }
-  readonly fakerOptions: { readonly arrayMin?: number; readonly arrayMax?: number }
+  readonly fakerOptions: FakerOptions
   readonly allRefs: Set<string>
   readonly exampleValue: unknown
   readonly exampleCast: string | undefined
@@ -398,9 +399,31 @@ export type MockOptions = {
   readonly arrayMin?: number
   readonly arrayMax?: number
   readonly readonly?: boolean
-  readonly useExamples?: boolean
+  /**
+   * `true` (default) answers with a response's media-level `example`/`examples`;
+   * `'all'` also uses the scalar `example`/`examples` of every schema and
+   * property; `false` always generates.
+   */
+  readonly useExamples?: boolean | 'all'
   readonly locale?: string
   readonly delay?: number | { readonly min: number; readonly max: number } | false
+  /**
+   * Re-seeds faker (and pins its reference date to `SEED_REF_DATE`) at the start
+   * of every handler, so each route answers the same body every time.
+   */
+  readonly seed?: number | readonly number[]
+}
+
+// `faker.date.*` is relative to the current time, so a seeded mock also pins
+// the reference date; otherwise every date (and a JWT's `iat`) would drift.
+const SEED_REF_DATE = '2025-01-01T00:00:00.000Z'
+
+// The knobs threaded into `schemaToFaker`; `useExamples` there means the
+// schema-level examples (`MockOptions['useExamples'] === 'all'`).
+type FakerOptions = {
+  readonly arrayMin?: number
+  readonly arrayMax?: number
+  readonly useExamples?: boolean
 }
 
 // Builds the optional response-delay middleware. A fixed `number` sleeps that
@@ -421,20 +444,26 @@ function delayMiddlewareCode(delay: MockOptions['delay']) {
 }
 
 export function makeMock(openapi: OpenAPI, basePath: string, options: MockOptions = {}) {
-  // Split the emit-shell knobs off; the rest is exactly the faker knobs
-  // (`arrayMin`/`arrayMax`), threaded into `schemaToFaker`. `useExamples` is
-  // destructured out (not threaded) so it
-  // gates the media-level example only (`extractMediaExample`); keeping it out of
-  // `fakerOptions` preserves the property-level example behavior in one place.
-  // It defaults to `true`: the mock has always preferred a spec-authored example.
+  // Split the emit-shell knobs off from the faker knobs threaded into
+  // `schemaToFaker`. `useExamples` defaults to `true` — the mock has always
+  // preferred a spec-authored response example — which gates the media-level
+  // example only (`extractMediaExample`); `'all'` additionally lets
+  // `schemaToFaker` use each schema's own scalar example.
   const {
     useExamples: useExamplesOption,
     locale,
     delay,
+    seed,
     readonly: readonlyOption,
-    ...fakerOptions
+    arrayMin,
+    arrayMax,
   } = options
   const useExamples = useExamplesOption ?? true
+  const fakerOptions: FakerOptions = {
+    ...(arrayMin !== undefined ? { arrayMin } : {}),
+    ...(arrayMax !== undefined ? { arrayMax } : {}),
+    ...(useExamples === 'all' ? { useExamples: true } : {}),
+  }
   const filteredOpenapi = filterToJsonContentTypes(openapi)
   const paths = filteredOpenapi.paths
   const schemas = openapi.components?.schemas ?? {}
@@ -459,7 +488,9 @@ export function makeMock(openapi: OpenAPI, basePath: string, options: MockOption
       const jsonSchema = jsonMedia && isMediaWithSchema(jsonMedia) ? jsonMedia.schema : undefined
       const textSchema = textMedia && isMediaWithSchema(textMedia) ? textMedia.schema : undefined
       const exampleValue =
-        useExamples && jsonMedia ? extractMediaExample(jsonMedia, openapi.components) : undefined
+        useExamples !== false && jsonMedia
+          ? extractMediaExample(jsonMedia, openapi.components)
+          : undefined
       const exampleCast =
         exampleValue !== undefined && jsonSchema?.$ref
           ? toIdentifierPascalCase(ensureSuffix(jsonSchema.$ref.split('/').at(-1) ?? '', 'Schema'))
@@ -499,7 +530,8 @@ export function makeMock(openapi: OpenAPI, basePath: string, options: MockOption
               const condition = pathParams
                 .map(
                   // oxlint-disable-next-line no-shadow -- the inner name is the natural one here
-                  (p) => `c.req.param('${p.name}') === '${getNonExistentValue(p.schema, schemas)}'`,
+                  (p) =>
+                    `c.req.param(${makeStringLiteral(p.name)}) === '${getNonExistentValue(p.schema, schemas)}'`,
                 )
                 .join(' || ')
               const notFoundJsonMedia = notFoundResponse.content?.['application/json']
@@ -521,7 +553,15 @@ export function makeMock(openapi: OpenAPI, basePath: string, options: MockOption
           : ''
       const usesContext = handlerBody.includes('c.') || authCheck !== '' || notFoundCheck !== ''
       const param = usesContext ? 'c' : '_c'
-      const handler = `const ${routeId}RouteHandler: RouteHandler<typeof ${routeId}Route> = async (${param}) => {${authCheck}${notFoundCheck}${handlerBody}}`
+      // Seeding inside the handler (not once at module load) makes a route's body
+      // independent of which requests ran before it, and the handler body runs
+      // synchronously after the seed, so concurrent requests cannot interleave.
+      const usesFaker = /\bfaker\.|\bmock[A-Za-z0-9_$]*\(/u.test(`${notFoundCheck}${handlerBody}`)
+      const seedCall =
+        seed !== undefined && usesFaker
+          ? `faker.seed(${JSON.stringify(seed)});faker.setDefaultRefDate('${SEED_REF_DATE}');`
+          : ''
+      const handler = `const ${routeId}RouteHandler: RouteHandler<typeof ${routeId}Route> = async (${param}) => {${seedCall}${authCheck}${notFoundCheck}${handlerBody}}`
       return [{ entry: { routeId, method, path: p, requiresAuth }, handler }]
     }),
   )

--- a/packages/hono-takibi/src/generator/mock/index.ts
+++ b/packages/hono-takibi/src/generator/mock/index.ts
@@ -12,6 +12,7 @@ import {
 import { getNonExistentValue, mockFunctionName, schemaToFaker } from '../../helper/faker.js'
 import type {
   Components,
+  Content,
   Media,
   OpenAPI,
   Operation,
@@ -298,6 +299,7 @@ function resolveSuccessResponse(
   const key = [...priority, ...others][0]
   if (!key) return undefined
   return {
+    key,
     statusCode: statusCodeToNumber(key),
     response: resolveResponse(responses[key], componentResponses),
   }
@@ -335,65 +337,198 @@ function makeAuthCheck(
   return `if(!(${authChecks.join(' || ')})){return c.json({ message: 'Unauthorized' }, 401)}`
 }
 
-// Reads a media object's representative example. Mirrors the docs generator's
-// `extractMediaExample`: `example` (singular) wins, otherwise the first entry of
-// `examples`. `$ref` entries resolve against `components.examples`;
-// `externalValue`-only entries yield `undefined` (the value lives outside the
-// document) so the handler falls back to faker.
-function extractMediaExample(media: Media, components: Components | undefined): unknown {
-  if (media.example !== undefined) return media.example
-  if (!media.examples) return undefined
-  const first = Object.values(media.examples)[0]
-  if (!first) return undefined
-  if ('$ref' in first && typeof first.$ref === 'string') {
-    const name = first.$ref.split('/').at(-1)
+// A media object's `examples` entry, resolved against `components.examples`.
+// An `externalValue`-only entry yields `undefined`: its value lives outside the
+// document.
+function exampleEntryValue(
+  entry: NonNullable<Media['examples']>[string],
+  components: Components | undefined,
+): unknown {
+  if ('$ref' in entry && typeof entry.$ref === 'string') {
+    const name = entry.$ref.split('/').at(-1)
     const resolved = name ? components?.examples?.[name] : undefined
     return resolved && 'value' in resolved ? resolved.value : undefined
   }
-  return 'value' in first ? first.value : undefined
+  return 'value' in entry ? entry.value : undefined
 }
 
-function makeHandlerBody(args: {
-  readonly statusCode: number
+// Reads a media object's representative example. Mirrors the docs generator's
+// `extractMediaExample`: `example` (singular) wins, otherwise the first entry of
+// `examples`, so the handler falls back to faker when that entry has no value.
+function extractMediaExample(media: Media, components: Components | undefined): unknown {
+  if (media.example !== undefined) return media.example
+  const first = Object.values(media.examples ?? {})[0]
+  return first ? exampleEntryValue(first, components) : undefined
+}
+
+// The media type answered through `c.json()`: `application/json` first, then any
+// `+json` suffix (`application/problem+json`, `application/vnd.api+json`), which
+// `@hono/zod-openapi` also types as JSON — error responses are commonly declared
+// as problem+json, and would otherwise mock to an empty body.
+function jsonMediaType(content: Content | undefined) {
+  const types = Object.keys(content ?? {})
+  return types.includes('application/json')
+    ? 'application/json'
+    : types.find((type) => /^application\/(?:[\w.-]+\+)?json(?:;|$)/u.test(type))
+}
+
+/** What a mock can answer for one declared response. */
+type MockResponse = {
+  /** The spec key (`404`, `4XX`, `default`), `XX` upper-cased. */
+  readonly key: string
+  readonly jsonType: string | undefined
   readonly jsonSchema: Schema | undefined
   readonly textSchema: Schema | undefined
-  readonly schemas: { readonly [k: string]: Schema }
-  readonly fakerOptions: FakerOptions
-  readonly allRefs: Set<string>
-  readonly exampleValue: unknown
+  /** The example answered by default (`useExamples`), if any. */
+  readonly example: unknown
+  /** The `examples` entries a `Prefer: example=<name>` can select. */
+  readonly namedExamples: readonly (readonly [string, unknown])[]
+  /** The schema const an authored example is cast to (a named `$ref` schema). */
   readonly exampleCast: string | undefined
-}) {
-  const {
-    statusCode,
+}
+
+function describeResponse(
+  key: string,
+  response: Responses,
+  components: Components | undefined,
+  useExamples: boolean,
+): MockResponse {
+  const jsonType = jsonMediaType(response.content)
+  const jsonMedia = jsonType ? response.content?.[jsonType] : undefined
+  const textMedia = response.content?.['text/plain']
+  const jsonSchema = jsonMedia && isMediaWithSchema(jsonMedia) ? jsonMedia.schema : undefined
+  return {
+    key: /^[1-5]xx$/iu.test(key) ? key.toUpperCase() : key,
+    jsonType,
     jsonSchema,
-    textSchema,
-    schemas,
-    fakerOptions,
-    allRefs,
-    exampleValue,
-    exampleCast,
-  } = args
-  // A spec-authored example is the strongest signal of intent: return it
-  // verbatim instead of faker. The cast mirrors the `x-brand` handling — an
-  // authored literal can be widened (e.g. `string` vs an enum/branded member),
-  // so it is pinned to the success schema's inferred type when that schema is a
-  // named `$ref`.
-  if (exampleValue !== undefined) {
-    const cast = exampleCast ? ` as z.infer<typeof ${exampleCast}>` : ''
-    return `return c.json(${JSON.stringify(exampleValue)}${cast}, ${statusCode})`
+    textSchema: textMedia && isMediaWithSchema(textMedia) ? textMedia.schema : undefined,
+    example: useExamples && jsonMedia ? extractMediaExample(jsonMedia, components) : undefined,
+    namedExamples: Object.entries(jsonMedia?.examples ?? {}).flatMap(([name, entry]) => {
+      const value = exampleEntryValue(entry, components)
+      return value === undefined ? [] : [[name, value] as const]
+    }),
+    exampleCast: jsonSchema?.$ref
+      ? toIdentifierPascalCase(ensureSuffix(jsonSchema.$ref.split('/').at(-1) ?? '', 'Schema'))
+      : undefined,
   }
-  if (jsonSchema) {
-    collectRefs(jsonSchema, allRefs)
-    const mockData = schemaToFaker(jsonSchema, undefined, { schemas, ...fakerOptions })
-    return `return c.json(${mockData}, ${statusCode})`
+}
+
+// The value expression and media of one answer: an authored example, else faker.
+function responsePayload(
+  response: MockResponse,
+  example: unknown,
+  schemas: { readonly [k: string]: Schema },
+  fakerOptions: FakerOptions,
+  allRefs: Set<string>,
+) {
+  if (example !== undefined) {
+    // An authored literal can be widened (e.g. `string` vs an enum/branded
+    // member), so it is pinned to the schema's inferred type when that schema
+    // is a named `$ref` — mirroring the `x-brand` handling.
+    const cast = response.exampleCast ? ` as z.infer<typeof ${response.exampleCast}>` : ''
+    return { kind: 'json', data: `${JSON.stringify(example)}${cast}` } as const
   }
-  if (textSchema) {
-    const mockData = schemaToFaker(textSchema, undefined, { schemas, ...fakerOptions })
-    return `return c.text(${mockData}, ${statusCode})`
+  if (response.jsonSchema) {
+    collectRefs(response.jsonSchema, allRefs)
+    const data = schemaToFaker(response.jsonSchema, undefined, { schemas, ...fakerOptions })
+    return { kind: 'json', data } as const
   }
+  if (response.textSchema) {
+    const data = schemaToFaker(response.textSchema, undefined, { schemas, ...fakerOptions })
+    return { kind: 'text', data } as const
+  }
+  return { kind: 'none' } as const
+}
+
+// Answers with a status the route declares literally, through the typed
+// `c.json`/`c.text`, so the body is checked against that response's schema.
+function makeHandlerBody(
+  statusCode: number,
+  response: MockResponse | undefined,
+  payload: ReturnType<typeof responsePayload>,
+) {
+  if (payload.kind === 'json') {
+    // `c.json` defaults the header to application/json; a `+json` type is kept.
+    const headers =
+      response?.jsonType && response.jsonType !== 'application/json'
+        ? `, { 'Content-Type': ${makeStringLiteral(response.jsonType)} }`
+        : ''
+    return `return c.json(${payload.data}, ${statusCode}${headers})`
+  }
+  if (payload.kind === 'text') return `return c.text(${payload.data}, ${statusCode})`
   if (statusCode === 204) return `return new Response(null, { status: 204 })`
   return `return c.body(null, ${statusCode})`
 }
+
+// Answers a `4XX`/`default` response, whose status is only known at runtime
+// (the `Prefer` code), so the route's types cannot name it: `preferResponse`
+// builds the `Response` directly.
+function makeRawHandlerBody(
+  statusExpr: string,
+  response: MockResponse,
+  payload: ReturnType<typeof responsePayload>,
+) {
+  if (payload.kind === 'json') {
+    const type = makeStringLiteral(response.jsonType ?? 'application/json')
+    return `return preferResponse(${statusExpr}, JSON.stringify(${payload.data}), ${type})`
+  }
+  if (payload.kind === 'text') {
+    return `return preferResponse(${statusExpr}, String(${payload.data}), 'text/plain')`
+  }
+  return `return preferResponse(${statusExpr}, null)`
+}
+
+// Module-level helpers for Prism-compatible response selection, emitted once
+// per mock file. The names carry no `mock` prefix so they can never collide
+// with a component factory (`mock<Name>`).
+const PREFER_HELPERS = `// Reads Prism's \`Prefer: code=<status>, example=<name>\` header (or the \`__code\` /
+// \`__example\` query) and resolves it against the responses the route declares:
+// the exact status, then its \`NXX\` range, then \`default\`. Without a code the
+// example is looked up in the success response. Anything the route does not
+// declare answers 500 problem+json, as Prism does.
+function resolvePrefer(
+  req: { header(name: string): string | undefined; query(name: string): string | undefined },
+  responses: { readonly [key: string]: readonly string[] },
+  success: string,
+) {
+  let code = req.query('__code')
+  let example = req.query('__example')
+  for (const [, name = '', quoted, bare] of (req.header('Prefer') ?? '').matchAll(
+    /([A-Za-z]+)\\s*=\\s*(?:"([^"]*)"|([^\\s,;]*))/gu,
+  )) {
+    if (name.toLowerCase() === 'code') code ??= quoted ?? bare
+    if (name.toLowerCase() === 'example') example ??= quoted ?? bare
+  }
+  if (code === undefined && example === undefined) return {}
+  if (code !== undefined && !/^[2-5]\\d\\d$/u.test(code)) {
+    preferProblem(\`Prefer code=\${code} is not a status code between 200 and 599.\`)
+  }
+  const key =
+    code === undefined
+      ? success
+      : [code, \`\${code.slice(0, 1)}XX\`, 'default'].find((k) => Object.hasOwn(responses, k))
+  if (key === undefined) preferProblem(\`No \${code} response is declared for this operation.\`)
+  if (example !== undefined && !responses[key]?.includes(example)) {
+    preferProblem(\`No example named "\${example}" is declared for the \${key} response.\`)
+  }
+  return { key, code, example }
+}
+
+// Answers with a status the route's types cannot name (a \`4XX\`/\`default\` response
+// picked at runtime); Hono's error handler sends \`res\` with that status.
+function preferResponse(status: number, body: string | null, contentType?: string): never {
+  throw new HTTPException(status as ContentfulStatusCode, {
+    res: new Response(body, contentType ? { headers: { 'Content-Type': contentType } } : {}),
+  })
+}
+
+function preferProblem(detail: string): never {
+  return preferResponse(
+    500,
+    JSON.stringify({ type: 'about:blank', title: 'Mock response unavailable', status: 500, detail }),
+    'application/problem+json',
+  )
+}`
 
 export type MockOptions = {
   readonly arrayMin?: number
@@ -482,35 +617,71 @@ export function makeMock(openapi: OpenAPI, basePath: string, options: MockOption
       const requiresAuth = security.length > 0
       const success = resolveSuccessResponse(operation.responses, componentResponses)
       const statusCode = success?.statusCode ?? 200
-      const successResponse = success?.response
-      const jsonMedia = successResponse?.content?.['application/json']
-      const textMedia = successResponse?.content?.['text/plain']
-      const jsonSchema = jsonMedia && isMediaWithSchema(jsonMedia) ? jsonMedia.schema : undefined
-      const textSchema = textMedia && isMediaWithSchema(textMedia) ? textMedia.schema : undefined
-      const exampleValue =
-        useExamples !== false && jsonMedia
-          ? extractMediaExample(jsonMedia, openapi.components)
-          : undefined
-      const exampleCast =
-        exampleValue !== undefined && jsonSchema?.$ref
-          ? toIdentifierPascalCase(ensureSuffix(jsonSchema.$ref.split('/').at(-1) ?? '', 'Schema'))
-          : undefined
-      const handlerBody = makeHandlerBody({
-        statusCode,
-        jsonSchema,
-        textSchema,
-        schemas,
-        fakerOptions,
-        allRefs,
-        exampleValue,
-        exampleCast,
+      const successKey = success?.key ?? '200'
+      const responses = Object.entries(operation.responses ?? {}).flatMap(([key, raw]) => {
+        const response = resolveResponse(raw, componentResponses)
+        return response
+          ? [describeResponse(key, response, openapi.components, useExamples !== false)]
+          : []
       })
+      const successResponse = responses.find((r) => r.key === successKey)
+      const handlerBody = makeHandlerBody(
+        statusCode,
+        successResponse,
+        successResponse
+          ? responsePayload(
+              successResponse,
+              successResponse.example,
+              schemas,
+              fakerOptions,
+              allRefs,
+            )
+          : { kind: 'none' },
+      )
+      // `Prefer: code=…, example=…` picks any declared response or named example
+      // (Prism's convention), so error states can be exercised on demand. A
+      // literally declared status answers through the typed `c.json`; a `4XX` /
+      // `default` one, whose status comes from the request, through
+      // `preferResponse`. The success response's default body stays the final
+      // return below.
+      const preferTable = JSON.stringify(
+        Object.fromEntries(responses.map((r) => [r.key, r.namedExamples.map(([name]) => name)])),
+      )
+      const preferBranches = responses
+        .flatMap((response) => {
+          const isLiteral = /^\d{3}$/u.test(response.key)
+          const key = JSON.stringify(response.key)
+          const render = (example: unknown) => {
+            const payload = responsePayload(response, example, schemas, fakerOptions, allRefs)
+            return isLiteral
+              ? makeHandlerBody(Number(response.key), response, payload)
+              : makeRawHandlerBody(
+                  `Number(prefer.code ?? ${statusCodeToNumber(response.key)})`,
+                  response,
+                  payload,
+                )
+          }
+          // An entry that is already the default answer (the first one) needs no branch.
+          const named = response.namedExamples
+            .filter(([, value]) => value !== response.example)
+            .map(
+              ([name, value]) =>
+                `if(prefer.key===${key}&&prefer.example===${JSON.stringify(name)}){${render(value)}}`,
+            )
+          const isFinalReturn = isLiteral && response.key === successKey
+          return isFinalReturn
+            ? named
+            : [...named, `if(prefer.key===${key}){${render(response.example)}}`]
+        })
+        .join('')
+      const preferCall = `resolvePrefer(c.req,${preferTable},${JSON.stringify(successKey)})`
       // Generate auth check code only when route defines a 401 Unauthorized response
       const has401 = operation.responses?.[String(401)] !== undefined
       const authCheck = makeAuthCheck(security, has401)
       // The generated test suite requests getNonExistentValue() sentinels for
       // routes declaring a 404, so the mock must answer 404 for exactly those
-      // values — the two generators share the sentinel as a contract.
+      // values — the two generators share the sentinel as a contract. An
+      // explicit `Prefer` wins over the sentinel.
       const pathParams = (operation.parameters ?? []).flatMap((rawParam) => {
         const resolved = rawParam.$ref
           ? (openapi.components?.parameters?.[
@@ -520,10 +691,7 @@ export function makeMock(openapi: OpenAPI, basePath: string, options: MockOption
         if (!(isParameter(resolved) && resolved.in === 'path')) return []
         return [{ name: resolved.name, schema: resolved.schema ?? { type: 'string' as const } }]
       })
-      const notFoundResponse =
-        operation.responses?.[String(404)] !== undefined
-          ? resolveResponse(operation.responses[String(404)], componentResponses)
-          : undefined
+      const notFoundResponse = responses.find((r) => r.key === '404')
       const notFoundCheck =
         notFoundResponse !== undefined && pathParams.length > 0
           ? (() => {
@@ -534,34 +702,30 @@ export function makeMock(openapi: OpenAPI, basePath: string, options: MockOption
                     `c.req.param(${makeStringLiteral(p.name)}) === '${getNonExistentValue(p.schema, schemas)}'`,
                 )
                 .join(' || ')
-              const notFoundJsonMedia = notFoundResponse.content?.['application/json']
-              const notFoundBody = makeHandlerBody({
-                statusCode: 404,
-                jsonSchema:
-                  notFoundJsonMedia && isMediaWithSchema(notFoundJsonMedia)
-                    ? notFoundJsonMedia.schema
-                    : undefined,
-                textSchema: undefined,
-                schemas,
-                fakerOptions,
-                allRefs,
-                exampleValue: undefined,
-                exampleCast: undefined,
-              })
-              return `if(${condition}){${notFoundBody}}`
+              const notFoundBody = makeHandlerBody(
+                404,
+                notFoundResponse,
+                responsePayload(notFoundResponse, undefined, schemas, fakerOptions, allRefs),
+              )
+              return `if(prefer.key===undefined&&(${condition})){${notFoundBody}}`
             })()
           : ''
-      const usesContext = handlerBody.includes('c.') || authCheck !== '' || notFoundCheck !== ''
-      const param = usesContext ? 'c' : '_c'
       // Seeding inside the handler (not once at module load) makes a route's body
       // independent of which requests ran before it, and the handler body runs
       // synchronously after the seed, so concurrent requests cannot interleave.
-      const usesFaker = /\bfaker\.|\bmock[A-Za-z0-9_$]*\(/u.test(`${notFoundCheck}${handlerBody}`)
+      const usesFaker = /\bfaker\.|\bmock[A-Za-z0-9_$]*\(/u.test(
+        `${preferBranches}${notFoundCheck}${handlerBody}`,
+      )
       const seedCall =
         seed !== undefined && usesFaker
           ? `faker.seed(${JSON.stringify(seed)});faker.setDefaultRefDate('${SEED_REF_DATE}');`
           : ''
-      const handler = `const ${routeId}RouteHandler: RouteHandler<typeof ${routeId}Route> = async (${param}) => {${seedCall}${authCheck}${notFoundCheck}${handlerBody}}`
+      // With nothing to branch on, the call still rejects an undeclared `Prefer`.
+      const preferCheck =
+        preferBranches === '' && notFoundCheck === ''
+          ? `${preferCall};`
+          : `const prefer=${preferCall};${preferBranches}`
+      const handler = `const ${routeId}RouteHandler: RouteHandler<typeof ${routeId}Route> = async (c) => {${seedCall}${authCheck}${preferCheck}${notFoundCheck}${handlerBody}}`
       return [{ entry: { routeId, method, path: p, requiresAuth }, handler }]
     }),
   )
@@ -657,8 +821,13 @@ export function makeMock(openapi: OpenAPI, basePath: string, options: MockOption
   const fakerImport = locale
     ? `import { faker } from '@faker-js/faker/locale/${locale}'`
     : `import { faker } from '@faker-js/faker'`
+  const usesPrefer = handlers.length > 0
   const imports = `import { OpenAPIHono, createRoute, z, type RouteHandler } from '@hono/zod-openapi'
-${fakerImport}${needsCookieImport ? `\nimport { getCookie } from 'hono/cookie'` : ''}`
+${fakerImport}${needsCookieImport ? `\nimport { getCookie } from 'hono/cookie'` : ''}${
+    usesPrefer
+      ? `\nimport { HTTPException } from 'hono/http-exception'\nimport type { ContentfulStatusCode } from 'hono/utils/http-status'`
+      : ''
+  }`
   const delayMiddleware = delayMiddlewareCode(delay)
   const appCode = `const app = new OpenAPIHono()${basePath !== '/' ? `.basePath('${basePath}')` : ''}${delayMiddleware}
 
@@ -671,6 +840,7 @@ export default app`
     components,
     routes,
     mockFunctionsJoined,
+    usesPrefer ? PREFER_HELPERS : '',
     handlersJoined,
     appCode,
   ]

--- a/packages/hono-takibi/src/generator/test/test-generator.ts
+++ b/packages/hono-takibi/src/generator/test/test-generator.ts
@@ -8,7 +8,7 @@ import {
   isSecurityArray,
   isSecurityScheme,
 } from '../../guard/index.js'
-import { getNonExistentValue, schemaToFaker } from '../../helper/faker.js'
+import { getNonExistentValue, mockFunctionName, schemaToFaker } from '../../helper/faker.js'
 import type { OpenAPI, Schema } from '../../openapi/index.js'
 import { cyclicNodes, methodPath } from '../../utils/index.js'
 
@@ -217,7 +217,7 @@ function makeMockFunctions(
   return topologicalOrder(usedSchemaNames, schemas)
     .map((name) => {
       const returnType = circular.has(name) ? ': any' : ''
-      return `function mock${name.replaceAll('.', '')}()${returnType} {\n  return ${schemaToFaker(schemas[name])}\n}`
+      return `function ${mockFunctionName(name)}()${returnType} {\n  return ${schemaToFaker(schemas[name])}\n}`
     })
     .join('\n\n')
 }

--- a/packages/hono-takibi/src/generator/zod-to-openapi/z/string.test.ts
+++ b/packages/hono-takibi/src/generator/zod-to-openapi/z/string.test.ts
@@ -803,6 +803,11 @@ describe('string', () => {
       [{ type: 'string', format: 'email', 'x-emailRegex': 'a/b' }, 'z.email({pattern:/a\\/b/})'],
       [{ type: 'string', format: 'uri', 'x-urlProtocol': 'a/b' }, 'z.url({protocol:/a\\/b/})'],
       [{ type: 'string', format: 'uri', 'x-urlHostname': 'a/b' }, 'z.url({hostname:/a\\/b/})'],
+      // A slash after an escaped backslash is unescaped; the look-behind used to miss it.
+      [
+        { type: 'string', pattern: '\\p{L}\\\\/);globalThis.pwned=true;(2' },
+        'z.string().regex(/\\p{L}\\\\\\/);globalThis.pwned=true;(2/u)',
+      ],
     ])('string(%o) → %s', (input, expected) => {
       expect(string(input)).toBe(expected)
     })
@@ -818,6 +823,9 @@ describe('string', () => {
       [{ type: 'string', format: 'email', 'x-emailRegex': '^[a-z]+@a/b$' }],
       [{ type: 'string', format: 'uri', 'x-urlProtocol': 'ht/tps?' }],
       [{ type: 'string', format: 'uri', 'x-urlHostname': 'a/b' }],
+      [{ type: 'string', pattern: '^a\\\\/b$' }],
+      [{ type: 'string', pattern: 'a\nb' }],
+      [{ type: 'string', pattern: 'a\\' }],
     ])('fmt(string(%o)) is ok', async (input) => {
       await expect(runGenerator(fmt(`export const X = ${string(input)}`))).resolves.toBeDefined()
     })

--- a/packages/hono-takibi/src/generator/zod-to-openapi/z/string.ts
+++ b/packages/hono-takibi/src/generator/zod-to-openapi/z/string.ts
@@ -63,7 +63,7 @@ function makeFormatOptions(schema: Schema): readonly string[] {
       return [
         regex
           ? `pattern:/${escapeRegexLiteral(regex)}/`
-          : preset && EMAIL_PATTERN_PRESET[preset]
+          : preset && Object.hasOwn(EMAIL_PATTERN_PRESET, preset)
             ? `pattern:z.regexes.${EMAIL_PATTERN_PRESET[preset]}`
             : undefined,
       ].filter((v) => v !== undefined)
@@ -192,7 +192,12 @@ export function string(
     return `${baseStr}${decodeStep}${validateStep}`
   }
 
-  const format = schema.format && FORMAT_STRING[schema.format]
+  // `Object.hasOwn`: a document `format: constructor` must not resolve to
+  // `Object.prototype.constructor` and be spliced into the output as source.
+  const format =
+    schema.format && Object.hasOwn(FORMAT_STRING, schema.format)
+      ? FORMAT_STRING[schema.format]
+      : undefined
   const isTransformFormat = !!(schema.format && TRANSFORM_FORMATS.has(schema.format))
   const isValidationFormat = !!(format && !isTransformFormat)
   // Transform extensions applied as pre-validation when paired with a

--- a/packages/hono-takibi/src/helper/faker.test.ts
+++ b/packages/hono-takibi/src/helper/faker.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vite-plus/test'
 
-import { schemaToFaker } from './faker.js'
+import type { Format } from '../openapi/index.js'
+import { getNonExistentValue, mockFunctionName, schemaToFaker } from './faker.js'
 
 describe('schemaToFaker', () => {
   describe('example values', () => {
@@ -323,15 +324,41 @@ describe('schemaToFaker', () => {
       )
     })
 
-    it.concurrent('uses pattern for string', () => {
+    // faker strips `^`/`$` only from a RegExp, and copies the `\/` a RegExp's
+    // `.source` always contains into the value, so the pattern goes in as a string.
+    it.concurrent('passes the pattern to faker as a string without anchors', () => {
       expect(schemaToFaker({ type: 'string', pattern: '^[A-Z]{3}$' })).toBe(
-        'faker.helpers.fromRegExp(/^[A-Z]{3}$/)',
+        "faker.helpers.fromRegExp('[A-Z]{3}')",
       )
     })
 
-    it.concurrent('escapes an unescaped forward slash in the pattern', () => {
+    it.concurrent('keeps a forward slash literal so the value can match the pattern', () => {
       expect(schemaToFaker({ type: 'string', pattern: 'a/b' })).toBe(
-        'faker.helpers.fromRegExp(/a\\/b/)',
+        "faker.helpers.fromRegExp('a/b')",
+      )
+    })
+
+    it.concurrent('drops the no-op escape of a forward slash', () => {
+      expect(schemaToFaker({ type: 'string', pattern: '^a\\/b$' })).toBe(
+        "faker.helpers.fromRegExp('a/b')",
+      )
+    })
+
+    it.concurrent('keeps an escaped trailing dollar (it is not an anchor)', () => {
+      expect(schemaToFaker({ type: 'string', pattern: '^a\\$' })).toBe(
+        "faker.helpers.fromRegExp('a\\\\$')",
+      )
+    })
+
+    it.concurrent('strips the end anchor after an escaped backslash', () => {
+      expect(schemaToFaker({ type: 'string', pattern: '^a\\\\$' })).toBe(
+        "faker.helpers.fromRegExp('a\\\\\\\\')",
+      )
+    })
+
+    it.concurrent('emits a pattern that tries to break out as an inert string literal', () => {
+      expect(schemaToFaker({ type: 'string', pattern: "x');globalThis.pwned=1;('\n" })).toBe(
+        "faker.helpers.fromRegExp('x\\');globalThis.pwned=1;(\\'\\n')",
       )
     })
   })
@@ -351,18 +378,31 @@ describe('schemaToFaker', () => {
       ).toBe('null')
     })
 
-    it.concurrent('uses object example', () => {
+    // A whole-object literal would widen enum members to `string` and cannot
+    // express `bigint`, so object/array examples are composed from their members.
+    it.concurrent('builds an object from its members instead of its own example', () => {
       expect(
-        schemaToFaker({ type: 'object', example: { key: 'value' } }, undefined, {
-          useExamples: true,
-        }),
-      ).toBe('{"key":"value"}')
+        schemaToFaker(
+          {
+            type: 'object',
+            example: { key: 'value' },
+            required: ['key'],
+            properties: { key: { type: 'string', example: 'from-property' } },
+          },
+          undefined,
+          { useExamples: true },
+        ),
+      ).toBe('{ key: "from-property" }')
     })
 
-    it.concurrent('uses array example', () => {
+    it.concurrent('builds an array from its items instead of its own example', () => {
       expect(
-        schemaToFaker({ type: 'array', example: [1, 2, 3] }, undefined, { useExamples: true }),
-      ).toBe('[1,2,3]')
+        schemaToFaker(
+          { type: 'array', example: [1, 2, 3], items: { type: 'integer', example: 7 } },
+          undefined,
+          { useExamples: true },
+        ),
+      ).toBe('Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, () => (7))')
     })
   })
 
@@ -425,13 +465,52 @@ describe('schemaToFaker', () => {
   })
 
   describe('object with additionalProperties only', () => {
-    it.concurrent('returns empty object when no explicit properties', () => {
+    it.concurrent('generates a few entries for a map', () => {
       expect(
         schemaToFaker({
           type: 'object',
           additionalProperties: { type: 'string' },
         }),
+      ).toBe(
+        'Object.fromEntries(Array.from({ length: faker.number.int({ min: 1, max: 3 }) }, () => [faker.string.alpha(8), faker.string.alpha({ length: { min: 5, max: 20 } })] satisfies [string, unknown]))',
+      )
+    })
+
+    it.concurrent('honors minProperties / maxProperties for a map', () => {
+      expect(
+        schemaToFaker({
+          type: 'object',
+          additionalProperties: { type: 'boolean' },
+          minProperties: 2,
+          maxProperties: 5,
+        }),
+      ).toBe(
+        'Object.fromEntries(Array.from({ length: faker.number.int({ min: 2, max: 5 }) }, () => [faker.string.alpha(8), faker.datatype.boolean()] satisfies [string, unknown]))',
+      )
+    })
+
+    it.concurrent('never inverts the entry count when only maxProperties is 0', () => {
+      expect(
+        schemaToFaker({
+          type: 'object',
+          additionalProperties: { type: 'boolean' },
+          maxProperties: 0,
+        }),
+      ).toContain('faker.number.int({ min: 0, max: 0 })')
+    })
+
+    it.concurrent('keeps a map with propertyNames empty (random keys would violate it)', () => {
+      expect(
+        schemaToFaker({
+          type: 'object',
+          additionalProperties: { type: 'string' },
+          propertyNames: { pattern: '^x-' },
+        }),
       ).toBe('{}')
+    })
+
+    it.concurrent('returns an empty object for a free-form object', () => {
+      expect(schemaToFaker({ type: 'object' })).toBe('{}')
     })
 
     it.concurrent('returns empty object for additionalProperties true', () => {
@@ -662,7 +741,7 @@ describe('schemaToFaker', () => {
 
     it.concurrent('respects pattern over the status hint', () => {
       expect(schemaToFaker({ type: 'string', pattern: '^[0-9]+$' }, 'status')).toBe(
-        'faker.helpers.fromRegExp(/^[0-9]+$/)',
+        "faker.helpers.fromRegExp('[0-9]+')",
       )
     })
 
@@ -854,6 +933,298 @@ describe('schemaToFaker', () => {
 
     it.concurrent('returns undefined for unknown type', () => {
       expect(schemaToFaker({ type: 'date' })).toBe('undefined')
+    })
+  })
+
+  describe('property names that are not identifiers', () => {
+    it.concurrent.each([
+      ['first-name', "'first-name'"],
+      ['user.name', "'user.name'"],
+      ['full name', "'full name'"],
+      ['1st', "'1st'"],
+      ["it's", "'it\\'s'"],
+    ])('quotes the %s key', (name, key) => {
+      expect(
+        schemaToFaker({
+          type: 'object',
+          required: [name],
+          properties: { [name]: { type: 'boolean' } },
+        }),
+      ).toBe(`{ ${key}: faker.datatype.boolean() }`)
+    })
+
+    it.concurrent('emits a key that is a JS expression as an inert string key', () => {
+      const name = 'a: (globalThis.pwned = true), b'
+      expect(
+        schemaToFaker({
+          type: 'object',
+          required: [name],
+          properties: { [name]: { type: 'boolean' } },
+        }),
+      ).toBe("{ 'a: (globalThis.pwned = true), b': faker.datatype.boolean() }")
+    })
+
+    it.concurrent('leaves identifier keys (reserved words included) unquoted', () => {
+      expect(
+        schemaToFaker({
+          type: 'object',
+          required: ['class', '$id'],
+          properties: { class: { type: 'boolean' }, $id: { type: 'boolean' } },
+        }),
+      ).toBe('{ class: faker.datatype.boolean(), $id: faker.datatype.boolean() }')
+    })
+  })
+
+  describe('mockFunctionName', () => {
+    it.concurrent.each([
+      ['User', 'mockUser'],
+      ['user', 'mockuser'],
+      ['api.v1.User', 'mockapiv1User'],
+      ['User_Profile', 'mockUser_Profile'],
+      ['User-Profile', 'mockUserProfile'],
+      ['User Profile', 'mockUserProfile'],
+    ])('%s -> %s', (name, expected) => {
+      expect(mockFunctionName(name)).toBe(expected)
+    })
+
+    it.concurrent('calls a hyphenated component through the same sanitized name', () => {
+      expect(schemaToFaker({ $ref: '#/components/schemas/User-Profile' })).toBe('mockUserProfile()')
+    })
+  })
+
+  describe('property-name hints respect the declared type', () => {
+    it.concurrent.each([
+      ['status', 'integer', 'faker.number.int({ min: 1, max: 1000 })'],
+      ['createdAt', 'integer', 'faker.number.int({ min: 1, max: 1000 })'],
+      ['type', 'integer', 'faker.number.int({ min: 1, max: 1000 })'],
+      ['price', 'integer', 'faker.number.int({ min: 1, max: 1000 })'],
+      ['name', 'number', 'faker.number.float({ min: 1, max: 1000, fractionDigits: 2 })'],
+      ['email', 'boolean', 'faker.datatype.boolean()'],
+    ] as const)('ignores the %s hint on a %s', (name, type, expected) => {
+      expect(schemaToFaker({ type }, name)).toBe(expected)
+    })
+
+    it.concurrent('keeps an integer hint on a number (every integer is a number)', () => {
+      expect(schemaToFaker({ type: 'number' }, 'age')).toBe(
+        'faker.number.int({ min: 1, max: 120 })',
+      )
+    })
+
+    it.concurrent('keeps using hints for an untyped schema', () => {
+      expect(schemaToFaker({}, 'email')).toBe('faker.internet.email()')
+    })
+
+    it.concurrent.each([
+      ['created_at', 'faker.date.past().toISOString()'],
+      ['first_name', 'faker.person.firstName()'],
+      ['first-name', 'faker.person.firstName()'],
+      ['zip_code', 'faker.location.zipCode()'],
+    ])('matches the snake/kebab-case name %s', (name, expected) => {
+      expect(schemaToFaker({ type: 'string' }, name)).toBe(expected)
+    })
+
+    it.concurrent.each(['constructor', 'toString', '__proto__', 'hasOwnProperty'])(
+      'does not resolve the Object.prototype member %s as a hint',
+      (name) => {
+        expect(schemaToFaker({ type: 'string' }, name)).toBe(
+          'faker.string.alpha({ length: { min: 5, max: 20 } })',
+        )
+      },
+    )
+  })
+
+  describe('format hints respect the declared type', () => {
+    it.concurrent('does not emit a bigint for a string int64', () => {
+      expect(schemaToFaker({ type: 'string', format: 'int64' })).toBe(
+        'faker.string.alpha({ length: { min: 5, max: 20 } })',
+      )
+    })
+
+    it.concurrent('does not emit a bigint for a number int64 (z.number(), not z.int64())', () => {
+      expect(schemaToFaker({ type: 'number', format: 'int64' })).toBe(
+        'faker.number.float({ min: 1, max: 1000, fractionDigits: 2 })',
+      )
+    })
+
+    it.concurrent('does not emit a string for an integer with a string format', () => {
+      expect(schemaToFaker({ type: 'integer', format: 'email' })).toBe(
+        'faker.number.int({ min: 1, max: 1000 })',
+      )
+    })
+
+    it.concurrent.each<[Format, string]>([
+      ['uuidv7', 'faker.string.uuid({ version: 7 })'],
+      ['ulid', 'faker.string.ulid()'],
+      ['nanoid', 'faker.string.nanoid()'],
+      ['jwt', 'faker.internet.jwt()'],
+      ['duration', '`P${faker.number.int({ min: 1, max: 30 })}D`'],
+      ['e164', "faker.phone.number({ style: 'international' })"],
+      ['cidrv4', '`${faker.internet.ipv4()}/${faker.number.int({ min: 0, max: 32 })}`'],
+    ])('maps the %s format', (format, expected) => {
+      expect(schemaToFaker({ type: 'string', format })).toBe(expected)
+    })
+  })
+
+  describe('OpenAPI 3.1 type arrays', () => {
+    it.concurrent('mocks a nullable string', () => {
+      expect(schemaToFaker({ type: ['string', 'null'] })).toBe(
+        'faker.helpers.arrayElement([faker.string.alpha({ length: { min: 5, max: 20 } }), null])',
+      )
+    })
+
+    it.concurrent('mocks a single-member type array as that type', () => {
+      expect(schemaToFaker({ type: ['integer'], minimum: 3, maximum: 4 })).toBe(
+        'faker.number.int({ min: 3, max: 4 })',
+      )
+    })
+
+    it.concurrent('picks the member the zod schema is built from', () => {
+      expect(schemaToFaker({ type: ['integer', 'string'] })).toBe(
+        'faker.string.alpha({ length: { min: 5, max: 20 } })',
+      )
+    })
+
+    it.concurrent('mocks a null-only type array as null', () => {
+      expect(schemaToFaker({ type: ['null'] })).toBe('null')
+    })
+
+    it.concurrent('mocks a nullable object with properties', () => {
+      expect(
+        schemaToFaker({
+          type: ['object', 'null'],
+          required: ['ok'],
+          properties: { ok: { type: 'boolean' } },
+        }),
+      ).toBe('faker.helpers.arrayElement([{ ok: faker.datatype.boolean() }, null])')
+    })
+
+    it.concurrent('keeps the property hint through the type array', () => {
+      expect(schemaToFaker({ type: ['string', 'null'] }, 'email')).toBe(
+        'faker.helpers.arrayElement([faker.internet.email(), null])',
+      )
+    })
+
+    it.concurrent('treats a type-array nullable property like a nullable one', () => {
+      expect(
+        schemaToFaker({
+          type: 'object',
+          properties: { nick: { type: ['string', 'null'] }, age: { type: ['integer', 'null'] } },
+          required: ['nick'],
+        }),
+      ).toBe(
+        '{ nick: faker.helpers.arrayElement([faker.string.alpha({ length: { min: 5, max: 20 } }), null]), age: faker.helpers.arrayElement([faker.number.int({ min: 1, max: 120 }), null]) }',
+      )
+    })
+  })
+
+  describe('array bounds from config never invert the spec bounds', () => {
+    it.concurrent('clamps arrayMin to maxItems', () => {
+      expect(
+        schemaToFaker({ type: 'array', items: { type: 'boolean' }, maxItems: 3 }, undefined, {
+          arrayMin: 5,
+        }),
+      ).toBe(
+        'Array.from({ length: faker.number.int({ min: 3, max: 3 }) }, () => (faker.datatype.boolean()))',
+      )
+    })
+
+    it.concurrent('raises arrayMax to minItems', () => {
+      expect(
+        schemaToFaker({ type: 'array', items: { type: 'boolean' }, minItems: 4 }, undefined, {
+          arrayMax: 2,
+        }),
+      ).toBe(
+        'Array.from({ length: faker.number.int({ min: 4, max: 4 }) }, () => (faker.datatype.boolean()))',
+      )
+    })
+
+    it.concurrent('keeps arrayMin/arrayMax that fit inside the spec bounds', () => {
+      expect(
+        schemaToFaker({ type: 'array', items: { type: 'boolean' }, maxItems: 8 }, undefined, {
+          arrayMin: 2,
+        }),
+      ).toBe(
+        'Array.from({ length: faker.number.int({ min: 2, max: 8 }) }, () => (faker.datatype.boolean()))',
+      )
+    })
+  })
+
+  describe('schema-level examples (useExamples)', () => {
+    const options = { useExamples: true }
+
+    it.concurrent('uses a property example', () => {
+      expect(
+        schemaToFaker(
+          {
+            type: 'object',
+            required: ['bio'],
+            properties: { bio: { type: 'string', example: 'Hi' } },
+          },
+          undefined,
+          options,
+        ),
+      ).toBe('{ bio: "Hi" }')
+    })
+
+    it.concurrent('reads the first entry of an OpenAPI 3.1 examples array', () => {
+      expect(
+        schemaToFaker({ type: 'string', examples: ['first', 'second'] }, undefined, options),
+      ).toBe('"first"')
+    })
+
+    it.concurrent('keeps an enum example literal so it satisfies z.enum', () => {
+      expect(
+        schemaToFaker({ type: 'string', enum: ['a', 'b'], example: 'b' }, undefined, options),
+      ).toBe('"b" as const')
+    })
+
+    it.concurrent('ignores an example that is not an enum member', () => {
+      expect(
+        schemaToFaker({ type: 'string', enum: ['a', 'b'], example: 'z' }, undefined, options),
+      ).toBe('faker.helpers.arrayElement(["a", "b"] as const)')
+    })
+
+    it.concurrent('emits an int64 example as a bigint', () => {
+      expect(
+        schemaToFaker({ type: 'integer', format: 'int64', example: 42 }, undefined, options),
+      ).toBe('42n')
+    })
+
+    it.concurrent('ignores an example whose type disagrees with the schema', () => {
+      expect(schemaToFaker({ type: 'integer', example: 'ten' }, undefined, options)).toBe(
+        'faker.number.int({ min: 1, max: 1000 })',
+      )
+      expect(schemaToFaker({ type: 'integer', example: 1.5 }, undefined, options)).toBe(
+        'faker.number.int({ min: 1, max: 1000 })',
+      )
+    })
+
+    it.concurrent('ignores an example next to a $ref (its type is unknown here)', () => {
+      expect(
+        schemaToFaker({ $ref: '#/components/schemas/Status', example: 'x' }, undefined, options),
+      ).toBe('mockStatus()')
+    })
+
+    it.concurrent('lets const win over an example', () => {
+      expect(schemaToFaker({ const: 'fixed', example: 'other' }, undefined, options)).toBe(
+        '"fixed" as const',
+      )
+    })
+
+    it.concurrent('ignores examples unless requested', () => {
+      expect(schemaToFaker({ type: 'string', examples: ['first'] })).toBe(
+        'faker.string.alpha({ length: { min: 5, max: 20 } })',
+      )
+    })
+  })
+
+  describe('getNonExistentValue', () => {
+    it.concurrent('uses -1 for an integer type array', () => {
+      expect(getNonExistentValue({ type: ['integer', 'null'] })).toBe('-1')
+    })
+
+    it.concurrent('follows the zod member priority for a mixed type array', () => {
+      expect(getNonExistentValue({ type: ['integer', 'string'] })).toBe('__non_existent__')
     })
   })
 })

--- a/packages/hono-takibi/src/helper/faker.ts
+++ b/packages/hono-takibi/src/helper/faker.ts
@@ -1,6 +1,11 @@
 import { isSchemaArray, isSchemaObject } from '../guard/index.js'
-import type { Schema } from '../openapi/index.js'
-import { escapeRegexLiteral } from '../utils/index.js'
+import type { Schema, Type } from '../openapi/index.js'
+import {
+  makeSafeKey,
+  makeStringLiteral,
+  normalizeTypes,
+  toIdentifierPascalCase,
+} from '../utils/index.js'
 
 const FORMAT_TO_FAKER: { [k: string]: string } = {
   date: 'faker.date.past().toISOString().slice(0, 10)',
@@ -33,6 +38,37 @@ const FORMAT_TO_FAKER: { [k: string]: string } = {
   bigint: 'faker.number.bigInt({ min: 0n, max: 9007199254740991n })',
   float: 'faker.number.float({ min: 0, max: 1000, fractionDigits: 2 })',
   double: 'faker.number.float({ min: 0, max: 1000000, fractionDigits: 4 })',
+  // The string formats the zod generator validates (`generator/zod-to-openapi/z/string.ts`),
+  // so a mocked value passes the route's own `z.<format>()` check.
+  uuidv4: 'faker.string.uuid({ version: 4 })',
+  uuidv6: 'faker.string.uuid({ version: 6 })',
+  uuidv7: 'faker.string.uuid({ version: 7 })',
+  guid: 'faker.string.uuid()',
+  ulid: 'faker.string.ulid()',
+  nanoid: 'faker.string.nanoid()',
+  // oxlint-disable-next-line no-template-curly-in-string -- the placeholder belongs to the emitted template literal
+  cuid: "`c${faker.string.alphanumeric({ length: 24, casing: 'lower' })}`",
+  cuid2: "faker.string.alphanumeric({ length: 24, casing: 'lower' })",
+  jwt: 'faker.internet.jwt()',
+  emoji: 'faker.internet.emoji()',
+  mac: 'faker.internet.mac()',
+  hex: "faker.string.hexadecimal({ length: 16, prefix: '' })",
+  base64: 'btoa(faker.string.alphanumeric(12))',
+  base64url: 'faker.string.alphanumeric(16)',
+  // oxlint-disable-next-line no-template-curly-in-string -- the placeholder belongs to the emitted template literal
+  cidrv4: '`${faker.internet.ipv4()}/${faker.number.int({ min: 0, max: 32 })}`',
+  // oxlint-disable-next-line no-template-curly-in-string -- the placeholder belongs to the emitted template literal
+  cidrv6: '`${faker.internet.ipv6()}/${faker.number.int({ min: 0, max: 128 })}`',
+  // oxlint-disable-next-line no-template-curly-in-string -- the placeholder belongs to the emitted template literal
+  duration: '`P${faker.number.int({ min: 1, max: 30 })}D`',
+  e164: "faker.phone.number({ style: 'international' })",
+  httpUrl: 'faker.internet.url()',
+  'uri-reference': 'faker.internet.url()',
+  iri: 'faker.internet.url()',
+  'iri-reference': 'faker.internet.url()',
+  'idn-email': 'faker.internet.email()',
+  'idn-hostname': 'faker.internet.domainName()',
+  decimal: 'faker.commerce.price()',
 }
 
 const TYPE_TO_FAKER: { [k: string]: string } = {
@@ -73,6 +109,117 @@ const PROPERTY_NAME_TO_FAKER: { [k: string]: string } = {
   quantity: 'faker.number.int({ min: 1, max: 100 })',
   count: 'faker.number.int({ min: 0, max: 1000 })',
   age: 'faker.number.int({ min: 1, max: 120 })',
+}
+
+// `Object.hasOwn`: a document value such as `format: constructor` or a property
+// named `toString` must not resolve to an `Object.prototype` member.
+function lookup(table: { readonly [k: string]: string }, key: string) {
+  return Object.hasOwn(table, key) ? table[key] : undefined
+}
+
+// The order the zod generator picks a member of a multi-type (`type: [...]`)
+// schema in (`generator/zod-to-openapi/index.ts`), so the mock produces the
+// type the route's own schema accepts.
+const TYPE_PRIORITY = ['string', 'number', 'integer', 'boolean', 'array', 'object', 'date'] as const
+
+// A format or property-name hint is only a guess, so it is used only when the
+// value it produces fits the declared `type` — otherwise the mock contradicts
+// the route's own response schema (a string `status` on an `integer` field).
+// The value is read off the expression's head (a template literal starts with
+// a backtick, so it stays a string). An untyped schema accepts any hint;
+// `number` also accepts an integer, and `integer` a bigint (`z.int64()`).
+function isHintCompatible(type: Type | undefined, expr: string) {
+  if (type === undefined) return true
+  const isInt = expr.startsWith('faker.number.int(')
+  if (type === 'integer') return isInt || expr.startsWith('faker.number.bigInt(')
+  if (type === 'number') return isInt || expr.startsWith('faker.number.float(')
+  if (type === 'string') return !expr.startsWith('faker.number.')
+  return false
+}
+
+// Also tried in camelCase, so `created_at` and `first-name` hit `createdAt` and `firstName`.
+function propertyNameHint(propertyName: string) {
+  return (
+    lookup(PROPERTY_NAME_TO_FAKER, propertyName) ??
+    lookup(
+      PROPERTY_NAME_TO_FAKER,
+      propertyName.replaceAll(/[_-]+([a-zA-Z0-9])/gu, (_: string, c: string) => c.toUpperCase()),
+    )
+  )
+}
+
+/**
+ * The name of the generated mock factory for a component schema. Kept as
+ * `mock<Name>` (dots dropped) whenever that is already an identifier, so
+ * existing output is unchanged; any other name (`User-Profile`) goes through
+ * the same sanitizer as the schema consts (`toIdentifierPascalCase`), since
+ * OpenAPI component names may contain `-`.
+ */
+export function mockFunctionName(refName: string) {
+  const stripped = refName.replaceAll('.', '')
+  return /^[A-Za-z0-9_$]+$/u.test(stripped)
+    ? `mock${stripped}`
+    : `mock${toIdentifierPascalCase(refName)}`
+}
+
+/**
+ * Rewrites a `pattern` into the string `faker.helpers.fromRegExp` samples.
+ *
+ * faker reads a `RegExp` argument through `.source`, where `/` is always
+ * escaped as `\/`, and copies that backslash into the value — so a regex
+ * literal can never produce a value containing `/` that matches the pattern.
+ * Passing a string avoids it, but faker only strips `^`/`$` from a `RegExp`,
+ * so the anchors (and the no-op `\/` escape) are removed here instead. The
+ * result is emitted as an escaped string literal, never as regex-literal code.
+ */
+function fakerPattern(pattern: string) {
+  return pattern
+    .replace(/^\^+/u, '')
+    .replace(/(?<!\\)(?:\\\\)*\$+$/u, (anchor) => anchor.replaceAll('$', ''))
+    .replaceAll(/\\([\s\S])/gu, (match: string, escaped: string) => (escaped === '/' ? '/' : match))
+}
+
+// Reads a schema's own example: `example` (OpenAPI 3.0), else the first entry
+// of JSON Schema's `examples` array (OpenAPI 3.1).
+function schemaExample(schema: Schema): unknown {
+  if (schema.example !== undefined) return schema.example
+  return Array.isArray(schema.examples) ? schema.examples[0] : undefined
+}
+
+// Renders a scalar example as code, or `undefined` when it cannot stand in for
+// the schema's type. Object and array examples are not used as a whole: their
+// literal would widen enum members to `string` and cannot express `bigint`, so
+// they are built from their members instead (whose own examples still apply).
+function exampleLiteral(schema: Schema) {
+  const example = schemaExample(schema)
+  if (example === undefined) return undefined
+  const types = normalizeTypes(schema.type)
+  // Without a declared type (a `$ref` or combinator sibling) the literal's type
+  // cannot be checked against the target, so the generated value is kept.
+  if (schema.$ref !== undefined || (types.length === 0 && !schema.enum)) return undefined
+  const isAccepted = (type: Type) => types.length === 0 || types.includes(type)
+  if (example === null) {
+    return types.includes('null') || schema.nullable === true ? 'null' : undefined
+  }
+  if (schema.enum && !schema.enum.some((member) => member === example)) return undefined
+  // An enum member must keep its literal type to satisfy the route's `z.enum`.
+  const asConst = schema.enum ? ' as const' : ''
+  if (typeof example === 'string') {
+    if (!isAccepted('string') || schema.format === 'binary') return undefined
+    return `${JSON.stringify(example)}${asConst}`
+  }
+  if (typeof example === 'number') {
+    const isBigint =
+      types.includes('integer') && (schema.format === 'int64' || schema.format === 'bigint')
+    if (isBigint) return Number.isInteger(example) ? `${BigInt(example)}n` : undefined
+    if (!(isAccepted('number') || isAccepted('integer'))) return undefined
+    if (!(isAccepted('number') || Number.isInteger(example))) return undefined
+    return `${JSON.stringify(example)}${asConst}`
+  }
+  if (typeof example === 'boolean') {
+    return isAccepted('boolean') ? `${example}${asConst}` : undefined
+  }
+  return undefined
 }
 
 function hasNumericConstraint(schema: Schema) {
@@ -177,13 +324,14 @@ function isKnownScalar(
   schemas: { readonly [k: string]: Schema } | undefined,
 ): boolean {
   const resolved = resolveRef(schema, schemas)
+  const types = normalizeTypes(resolved.type)
   if (resolved.enum || resolved.const !== undefined) return true
-  if (resolved.properties || resolved.type === 'object') return false
+  if (resolved.properties || types.includes('object')) return false
   if (resolved.allOf && resolved.allOf.length > 0) {
     return resolved.allOf.every((s) => isKnownScalar(s, schemas))
   }
-  if (resolved.oneOf || resolved.anyOf || resolved.type === 'array') return false
-  return typeof resolved.type === 'string'
+  if (resolved.oneOf || resolved.anyOf || types.includes('array')) return false
+  return types.length > 0
 }
 
 export function schemaToFaker(
@@ -196,11 +344,12 @@ export function schemaToFaker(
     readonly schemas?: { readonly [k: string]: Schema }
   } = {},
 ): string {
-  if (options.useExamples && schema.example !== undefined) {
-    return JSON.stringify(schema.example)
-  }
   if (schema.const !== undefined) {
     return `${JSON.stringify(schema.const)} as const`
+  }
+  if (options.useExamples) {
+    const example = exampleLiteral(schema)
+    if (example !== undefined) return example
   }
   if (schema.enum && schema.enum.length > 0) {
     const values = schema.enum.map((v) => JSON.stringify(v)).join(', ')
@@ -209,7 +358,20 @@ export function schemaToFaker(
   if (schema.$ref) {
     // oxlint-disable-next-line typescript/prefer-nullish-coalescing -- an empty trailing segment falls back too
     const refName = schema.$ref.split('/').pop() || 'unknown'
-    return `mock${refName.replaceAll('.', '')}()`
+    return `${mockFunctionName(refName)}()`
+  }
+  // OpenAPI 3.1 / JSON Schema type array: mock the member the zod schema is
+  // built from (`TYPE_PRIORITY`, `properties` meaning an object), and let a
+  // `'null'` member yield `null` too — the same `.nullable()` zod applies.
+  if (Array.isArray(schema.type)) {
+    const types: readonly Type[] = schema.type
+    const primary =
+      schema.properties !== undefined && types.includes('object')
+        ? 'object'
+        : TYPE_PRIORITY.find((t) => types.includes(t))
+    if (primary === undefined) return types.includes('null') ? 'null' : 'undefined'
+    const value = schemaToFaker({ ...schema, type: primary }, propertyName, options)
+    return types.includes('null') ? `faker.helpers.arrayElement([${value}, null])` : value
   }
   if (schema.type === 'array' && schema.items) {
     const itemSchema = isSchemaArray(schema.items) ? schema.items[0] : schema.items
@@ -217,11 +379,12 @@ export function schemaToFaker(
     const itemFaker = schemaToFaker(itemSchema, undefined, options)
     // A spec `minItems`/`maxItems` wins so the array satisfies the route's own
     // response schema (which enforces them); `arrayMin`/`arrayMax` then `1`/`10`
-    // fill an unconstrained side. The default upper bound floors to `min` so a
-    // lone `minItems` never yields an inverted `{ min, max }` (an explicit
-    // `maxItems` is still honored verbatim, mirroring the numeric range).
-    const min = schema.minItems ?? options.arrayMin ?? 1
-    const max = schema.maxItems ?? options.arrayMax ?? Math.max(min, 10)
+    // fill an unconstrained side, clamped against the spec side so a config
+    // bound never inverts the range (`arrayMin: 5` with `maxItems: 3` → 3..3).
+    // An inverted range written in the spec itself is passed through verbatim,
+    // mirroring the numeric range.
+    const min = schema.minItems ?? Math.min(options.arrayMin ?? 1, schema.maxItems ?? Infinity)
+    const max = schema.maxItems ?? Math.max(options.arrayMax ?? 10, min)
     return `Array.from({ length: faker.number.int({ min: ${min}, max: ${max} }) }, () => (${itemFaker}))`
   }
   const renderProps = (
@@ -231,16 +394,19 @@ export function schemaToFaker(
     const requiredSet = new Set(required)
     return Object.entries(properties)
       .map(([k, v]) => {
+        const key = makeSafeKey(k)
         const value = schemaToFaker(v, k, options)
+        // A `type: [..., 'null']` member already yields `null` from its own value.
+        const isNullable = v.nullable === true || normalizeTypes(v.type).includes('null')
         // An optional property may be absent and a nullable one may be null, so
         // the mock exercises both — staying faithful to what the spec allows.
-        if (!(requiredSet.has(k) || v.nullable)) {
-          return `${k}: faker.helpers.arrayElement([${value}, undefined])`
+        if (!(requiredSet.has(k) || isNullable)) {
+          return `${key}: faker.helpers.arrayElement([${value}, undefined])`
         }
         if (v.nullable) {
-          return `${k}: faker.helpers.arrayElement([${value}, null])`
+          return `${key}: faker.helpers.arrayElement([${value}, null])`
         }
-        return `${k}: ${value}`
+        return `${key}: ${value}`
       })
       .join(', ')
   }
@@ -248,7 +414,21 @@ export function schemaToFaker(
     return `{ ${renderProps(schema.properties, schema.required)} }`
   }
   if (schema.type === 'object' && !schema.properties && schema.additionalProperties) {
-    return '{}'
+    // A map (`z.record(z.string(), X)`) gets a few entries so consumers see its
+    // shape. `additionalProperties: true` says nothing about the values, and
+    // `propertyNames`/`patternProperties` constrain keys a random key would
+    // violate, so those stay `{}`.
+    if (
+      typeof schema.additionalProperties === 'boolean' ||
+      schema.propertyNames !== undefined ||
+      schema.patternProperties !== undefined
+    ) {
+      return '{}'
+    }
+    const value = schemaToFaker(schema.additionalProperties, undefined, options)
+    const max = schema.maxProperties ?? Math.max(schema.minProperties ?? 1, 3)
+    const min = schema.minProperties ?? Math.min(1, max)
+    return `Object.fromEntries(Array.from({ length: faker.number.int({ min: ${min}, max: ${max} }) }, () => [faker.string.alpha(8), ${value}] satisfies [string, unknown]))`
   }
   if (schema.allOf && schema.allOf.length > 0) {
     // A scalar refinement (`allOf` of only scalar/enum members, no own
@@ -292,42 +472,46 @@ export function schemaToFaker(
   }
   // Numeric constraints win over format/property-name defaults so generated
   // values satisfy the schema's bounds (minimum/maximum/exclusive*/multipleOf).
-  if ((schema.type === 'integer' || schema.type === 'number') && hasNumericConstraint(schema)) {
-    return numericFaker(schema, numericRange(schema, schema.type === 'integer'))
+  // Type arrays were narrowed to a single member above.
+  const type = typeof schema.type === 'string' ? schema.type : undefined
+  if ((type === 'integer' || type === 'number') && hasNumericConstraint(schema)) {
+    return numericFaker(schema, numericRange(schema, type === 'integer'))
   }
-  if (schema.format && FORMAT_TO_FAKER[schema.format]) {
-    return FORMAT_TO_FAKER[schema.format]
+  const formatHint = schema.format ? lookup(FORMAT_TO_FAKER, schema.format) : undefined
+  if (formatHint && isHintCompatible(type, formatHint)) {
+    return formatHint
   }
-  // A property-name hint is a guess; explicit string constraints are the
-  // schema's own contract. A hint that ignores `pattern`/`minLength`/`maxLength`
-  // can emit values the response schema itself rejects (422 in the host app),
-  // so constrained strings fall through to the constraint-aware string branch.
-  if (propertyName && PROPERTY_NAME_TO_FAKER[propertyName]) {
-    const hint = PROPERTY_NAME_TO_FAKER[propertyName]
-    const isNumberHint = hint.includes('faker.number.')
+  // A property-name hint is a guess; the declared `type` and explicit string
+  // constraints are the schema's own contract. A hint that ignores them emits
+  // values the response schema itself rejects (a string `status` on an
+  // `integer`, or a `pattern`-violating string — 422 in the host app), so such
+  // schemas fall through to the type/constraint-aware branches below.
+  const nameHint = propertyName ? propertyNameHint(propertyName) : undefined
+  if (nameHint && isHintCompatible(type, nameHint)) {
     const hasStringConstraint =
       schema.pattern !== undefined ||
       schema.minLength !== undefined ||
       schema.maxLength !== undefined
-    if (!(schema.type === 'string' && (isNumberHint || hasStringConstraint))) {
-      return hint
+    if (!(type === 'string' && hasStringConstraint)) {
+      return nameHint
     }
   }
-  if (schema.type && typeof schema.type === 'string' && TYPE_TO_FAKER[schema.type]) {
-    if (schema.type === 'string') {
-      if (schema.pattern) {
-        return `faker.helpers.fromRegExp(/${escapeRegexLiteral(schema.pattern)}/)`
-      }
-      const min = schema.minLength ?? 5
-      const max = schema.maxLength ?? Math.max(min, 20)
-      return `faker.string.alpha({ length: { min: ${min}, max: ${max} } })`
+  if (type === 'string') {
+    if (schema.pattern) {
+      return `faker.helpers.fromRegExp(${makeStringLiteral(fakerPattern(schema.pattern))})`
     }
-    if (schema.type === 'integer' || schema.type === 'number') {
-      return numericFaker(schema, numericRange(schema, schema.type === 'integer'))
-    }
-    return TYPE_TO_FAKER[schema.type]
+    const min = schema.minLength ?? 5
+    const max = schema.maxLength ?? Math.max(min, 20)
+    return `faker.string.alpha({ length: { min: ${min}, max: ${max} } })`
   }
-  return 'undefined'
+  if (type === 'integer' || type === 'number') {
+    return numericFaker(schema, numericRange(schema, type === 'integer'))
+  }
+  // A free-form object (`type: object` with neither `properties` nor
+  // `additionalProperties`) is `z.object({})`, which `{}` satisfies.
+  if (type === 'object') return '{}'
+  if (type === 'array') return '[]'
+  return (type ? lookup(TYPE_TO_FAKER, type) : undefined) ?? 'undefined'
 }
 
 /**
@@ -341,7 +525,9 @@ export function getNonExistentValue(schema?: Schema, schemas?: { readonly [k: st
     schema.$ref && schemas
       ? (schemas[schema.$ref.replace('#/components/schemas/', '')] ?? schema)
       : schema
-  if (resolved.type === 'integer' || resolved.type === 'number') return '-1'
+  const types = normalizeTypes(resolved.type)
+  const primary = TYPE_PRIORITY.find((t) => types.includes(t))
+  if (primary === 'integer' || primary === 'number') return '-1'
   if (resolved.format === 'uuid') return '00000000-0000-0000-0000-000000000000'
   return '__non_existent__'
 }

--- a/packages/hono-takibi/src/helper/handler.ts
+++ b/packages/hono-takibi/src/helper/handler.ts
@@ -24,7 +24,7 @@ import {
 import type { OpenAPI, Operation, Schema } from '../openapi/index.js'
 import { methodPath, uncapitalizeWord } from '../utils/index.js'
 import { makeImports, makeModuleSpec } from './code.js'
-import { schemaToFaker } from './faker.js'
+import { mockFunctionName, schemaToFaker } from './faker.js'
 
 function makeRefs(schema: Schema, refs = new Set<string>()) {
   if (schema.$ref) {
@@ -62,7 +62,7 @@ function makeRefs(schema: Schema, refs = new Set<string>()) {
 
 function makeMockFunction(name: string, schema: Schema, schemas: { readonly [k: string]: Schema }) {
   const mockBody = schemaToFaker(schema, undefined, { schemas })
-  return `function mock${name}() {\n  return ${mockBody}\n}`
+  return `function ${mockFunctionName(name)}() {\n  return ${mockBody}\n}`
 }
 
 function makeResponseInfo(operation: Operation) {

--- a/packages/hono-takibi/src/openapi/index.ts
+++ b/packages/hono-takibi/src/openapi/index.ts
@@ -408,18 +408,21 @@ export type Schema = {
   }
   readonly externalDocs?: ExternalDocs
   readonly example?: unknown
-  readonly examples?: {
-    readonly [k: string]:
-      | {
-          readonly summary?: string
-          readonly description?: string
-          readonly defaultValue?: unknown
-          readonly serializedValue?: string
-          readonly externalValue?: string
-          readonly value?: unknown
-        }
-      | Reference
-  }
+  /** An array of values in OpenAPI 3.1 / JSON Schema 2020-12; the keyed map is the 3.0 shape. */
+  readonly examples?:
+    | readonly unknown[]
+    | {
+        readonly [k: string]:
+          | {
+              readonly summary?: string
+              readonly description?: string
+              readonly defaultValue?: unknown
+              readonly serializedValue?: string
+              readonly externalValue?: string
+              readonly value?: unknown
+            }
+          | Reference
+      }
   readonly title?: string
   readonly name?: string
   readonly description?: string

--- a/packages/hono-takibi/src/utils/index.test.ts
+++ b/packages/hono-takibi/src/utils/index.test.ts
@@ -11,6 +11,7 @@ import {
   makeBarrel,
   makeInferRequestType,
   makeSafeKey,
+  makeStringLiteral,
   methodPath,
   normalizeTypes,
   renderNamedImport,
@@ -531,6 +532,45 @@ export * from './user'
       expect(escapeRegexLiteral('x/}); evil(); z.string({a:/y')).toBe(
         'x\\/}); evil(); z.string({a:\\/y',
       )
+    })
+
+    it('escapes a slash that follows an escaped backslash', () => {
+      expect(escapeRegexLiteral('a\\\\/b')).toBe('a\\\\\\/b')
+    })
+
+    it('neutralizes a breakout that hides the slash behind an escaped backslash', () => {
+      // `\\/` used to pass the look-behind: the literal ended at the slash and the
+      // rest ran as code once the `u` flag made the tail `(2/u)` parse.
+      const escaped = escapeRegexLiteral('\\p{L}\\\\/);globalThis.pwned=true;(2')
+      expect(escaped).toBe('\\p{L}\\\\\\/);globalThis.pwned=true;(2')
+    })
+
+    it('keeps an escaped slash as one escape', () => {
+      expect(escapeRegexLiteral('a\\/b\\\\\\/c')).toBe('a\\/b\\\\\\/c')
+    })
+
+    it('rewrites line terminators, which a regex literal cannot contain', () => {
+      expect(escapeRegexLiteral('a\nb\rc\u2028d\u2029e')).toBe('a\\nb\\rc\\u2028d\\u2029e')
+    })
+
+    it('rewrites an escaped line terminator to its escape sequence', () => {
+      expect(escapeRegexLiteral('a\\\nb')).toBe('a\\nb')
+    })
+
+    it('doubles a trailing lone backslash so it cannot escape the closing slash', () => {
+      expect(escapeRegexLiteral('a\\')).toBe('a\\\\')
+    })
+  })
+
+  describe('makeStringLiteral', () => {
+    it.concurrent.each([
+      ['X-API-Key', "'X-API-Key'"],
+      ["it's", "'it\\'s'"],
+      ['a\\b', "'a\\\\b'"],
+      ['a\nb', "'a\\nb'"],
+      ["x'); evil(); ('", "'x\\'); evil(); (\\''"],
+    ])('makeStringLiteral(%j) -> %s', (input, expected) => {
+      expect(makeStringLiteral(input)).toBe(expected)
     })
   })
 

--- a/packages/hono-takibi/src/utils/index.ts
+++ b/packages/hono-takibi/src/utils/index.ts
@@ -84,13 +84,39 @@ export function requestParamsArray(parameters: {
  */
 export function makeSafeKey(key: string) {
   if (/^[A-Za-z_$][A-Za-z0-9_$]*$/u.test(key)) return key
-  const escaped = key
+  return makeStringLiteral(key)
+}
+
+/**
+ * Converts a string to a single-quoted TypeScript string literal.
+ *
+ * Use it for every document-supplied value spliced into generated code as a
+ * string (header, query, cookie and path parameter names, …): a raw `'` or
+ * line break would otherwise end the literal and let the rest run as code.
+ *
+ *
+ * @example
+ * ```ts
+ * makeStringLiteral('X-API-Key')  // → "'X-API-Key'"
+ * makeStringLiteral("it's")       // → "'it\\'s'"
+ * makeStringLiteral('a\nb')       // → "'a\\nb'"
+ * ```
+ */
+export function makeStringLiteral(value: string) {
+  const escaped = value
     .replaceAll('\\', '\\\\')
     .replaceAll("'", "\\'")
     .replaceAll('\n', '\\n')
     .replaceAll('\r', '\\r')
     .replaceAll('	', '\\t')
   return `'${escaped}'`
+}
+
+const REGEX_LINE_TERMINATOR_ESCAPES: { readonly [k: string]: string } = {
+  '\n': '\\n',
+  '\r': '\\r',
+  '\u2028': '\\u2028',
+  '\u2029': '\\u2029',
 }
 
 /**
@@ -102,16 +128,32 @@ export function makeSafeKey(key: string) {
  * generated literal — an unescaped `/` would close it and let arbitrary code
  * follow. Slashes already escaped (`\/`) are left untouched.
  *
+ * The source is scanned as escape pairs, so a slash after an escaped backslash
+ * (`\\/`) is still recognised as unescaped. Line terminators, which a regex
+ * literal cannot contain, become their escape sequences (same meaning), and a
+ * trailing lone backslash — which would escape the closing `/` — is doubled.
+ *
  *
  * @example
  * ```ts
  * escapeRegexLiteral('^https?$')   // → '^https?$'
  * escapeRegexLiteral('a/b')        // → 'a\\/b'
  * escapeRegexLiteral('a\\/b')      // → 'a\\/b'
+ * escapeRegexLiteral('a\\\\/b')    // → 'a\\\\\\/b'
+ * escapeRegexLiteral('a\nb')       // → 'a\\nb'
  * ```
  */
 export function escapeRegexLiteral(source: string) {
-  return source.replaceAll(/(?<!\\)\//gu, '\\/')
+  return source.replaceAll(
+    /\\([\s\S]?)|[/\n\r\u2028\u2029]/gu,
+    (match: string, escaped: string | undefined) => {
+      if (escaped === undefined) {
+        return match === '/' ? '\\/' : (REGEX_LINE_TERMINATOR_ESCAPES[match] ?? match)
+      }
+      if (escaped === '') return '\\\\'
+      return REGEX_LINE_TERMINATOR_ESCAPES[escaped] ?? match
+    },
+  )
 }
 
 /**

--- a/test/cases/mock-edge/hono-takibi.config.ts
+++ b/test/cases/mock-edge/hono-takibi.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'hono-takibi'
+
+export default defineConfig({
+  input: '../../specs/mock-edge.yaml',
+  mock: {
+    output: '../../__generated__/mock-edge/mock.ts',
+    useExamples: 'all',
+    arrayMin: 5,
+  },
+})

--- a/test/cases/mock-edge/tsconfig.json
+++ b/test/cases/mock-edge/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["../../__generated__/mock-edge/**/*"]
+}

--- a/test/cases/mock-seed/hono-takibi.config.ts
+++ b/test/cases/mock-seed/hono-takibi.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'hono-takibi'
+
+export default defineConfig({
+  input: '../../specs/mock-edge.yaml',
+  mock: {
+    output: '../../__generated__/mock-seed/mock.ts',
+    locale: 'ja',
+    seed: 42,
+  },
+})

--- a/test/cases/mock-seed/tsconfig.json
+++ b/test/cases/mock-seed/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["../../__generated__/mock-seed/**/*"]
+}

--- a/test/runtime/mock-edge.test.ts
+++ b/test/runtime/mock-edge.test.ts
@@ -1,0 +1,88 @@
+// Verifies the generated mock against its own route schemas (cases/mock-edge, cases/mock-seed):
+// non-identifier property/component names, property-name hints that disagree with the
+// declared type, OpenAPI 3.1 type arrays, arrayMin clamped by maxItems, maps, schema-level
+// examples (`useExamples: 'all'`) and every zod string format are sampled repeatedly with
+// the real faker and parsed by the response schema the route declares. `seed` must make
+// each route answer the same body regardless of request order, on a locale faker instance.
+import { describe, expect, it } from 'vite-plus/test'
+
+import app, { getFormatsRoute, getUsersUserIdRoute } from '../__generated__/mock-edge/mock'
+import seededApp from '../__generated__/mock-seed/mock'
+
+const SAMPLES = 50
+const auth = { headers: { 'X-API-Key': 'key' } }
+const userSchema = getUsersUserIdRoute.responses[200].content['application/json'].schema
+const problemSchema = getUsersUserIdRoute.responses[404].content['application/json'].schema
+const formatsSchema = getFormatsRoute.responses[200].content['application/json'].schema
+
+async function seededText(path: string) {
+  const res = await seededApp.request(path, auth)
+  return res.text()
+}
+
+describe('mock responses satisfy the route schema', () => {
+  it('answers GET /users/{userId} with a body its response schema accepts', async () => {
+    for (let i = 0; i < SAMPLES; i += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential sampling of one route
+      const res = await app.request('/users/1', auth)
+      expect(res.status).toBe(200)
+      // oxlint-disable-next-line no-await-in-loop -- sequential sampling of one route
+      const body: unknown = await res.json()
+      const parsed = userSchema.safeParse(body)
+      expect(parsed.error).toBeUndefined()
+    }
+  })
+
+  it('answers GET /formats with a value every zod string format accepts', async () => {
+    for (let i = 0; i < SAMPLES; i += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential sampling of one route
+      const res = await app.request('/formats')
+      // oxlint-disable-next-line no-await-in-loop -- sequential sampling of one route
+      const body: unknown = await res.json()
+      const parsed = formatsSchema.safeParse(body)
+      expect(parsed.error).toBeUndefined()
+    }
+  })
+
+  it('answers the 404 sentinel with a problem body whose status is an integer', async () => {
+    const res = await app.request('/users/-1', auth)
+    expect(res.status).toBe(404)
+    const parsed = problemSchema.safeParse(await res.json())
+    expect(parsed.error).toBeUndefined()
+  })
+
+  it('answers 401 without the apiKey header', async () => {
+    const res = await app.request('/users/1')
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('mock option semantics', () => {
+  it('clamps arrayMin to maxItems and fills a map, using schema-level examples', async () => {
+    const res = await app.request('/users/1', auth)
+    const user = userSchema.parse(await res.json())
+    expect(user.tags).toHaveLength(3)
+    expect(Object.keys(user.labels).length).toBeGreaterThan(0)
+    expect(user.role).toBe('admin')
+    expect(user.bio).toBe('Hello')
+  })
+
+  it('answers the same body for a route regardless of request order when seeded', async () => {
+    const first = await seededText('/users/1')
+    await seededText('/formats')
+    await seededText('/formats')
+    expect(await seededText('/users/1')).toBe(first)
+    const formats = await seededText('/formats')
+    expect(await seededText('/formats')).toBe(formats)
+  })
+
+  it('stays deterministic under concurrent requests when seeded', async () => {
+    const bodies = await Promise.all(
+      Array.from({ length: 10 }, (_, i) => seededText(i % 2 === 0 ? '/users/1' : '/formats')),
+    )
+    const users = bodies.filter((_, i) => i % 2 === 0)
+    const formats = bodies.filter((_, i) => i % 2 === 1)
+    expect(new Set(users).size).toBe(1)
+    expect(new Set(formats).size).toBe(1)
+  })
+})

--- a/test/runtime/mock-edge.test.ts
+++ b/test/runtime/mock-edge.test.ts
@@ -6,7 +6,11 @@
 // each route answer the same body regardless of request order, on a locale faker instance.
 import { describe, expect, it } from 'vite-plus/test'
 
-import app, { getFormatsRoute, getUsersUserIdRoute } from '../__generated__/mock-edge/mock'
+import app, {
+  getFormatsRoute,
+  getOrdersOrderIdRoute,
+  getUsersUserIdRoute,
+} from '../__generated__/mock-edge/mock'
 import seededApp from '../__generated__/mock-seed/mock'
 
 const SAMPLES = 50
@@ -84,5 +88,107 @@ describe('mock option semantics', () => {
     const formats = bodies.filter((_, i) => i % 2 === 1)
     expect(new Set(users).size).toBe(1)
     expect(new Set(formats).size).toBe(1)
+  })
+})
+
+async function order(prefer?: string, query = '') {
+  const res = await app.request(
+    `/orders/o-1${query}`,
+    prefer ? { headers: { Prefer: prefer } } : {},
+  )
+  const text = await res.text()
+  return { status: res.status, type: res.headers.get('Content-Type'), text }
+}
+
+// Prism-compatible selection: `Prefer: code=<status>, example=<name>` (or `__code` /
+// `__example`) picks any declared response or named example; anything undeclared
+// answers 500 problem+json.
+describe('Prefer header selects a declared response', () => {
+  const orderSchema = getOrdersOrderIdRoute.responses[200].content['application/json'].schema
+  const problemJsonSchema =
+    getOrdersOrderIdRoute.responses[404].content['application/problem+json'].schema
+
+  it('answers the first example of the success response by default', async () => {
+    const res = await order()
+    expect(res.status).toBe(200)
+    expect(JSON.parse(res.text)).toStrictEqual({ id: 'o-1', state: 'shipped' })
+  })
+
+  it('selects a named example of the success response', async () => {
+    const res = await order('example=pending')
+    expect(res.status).toBe(200)
+    expect(orderSchema.parse(JSON.parse(res.text))).toStrictEqual({ id: 'o-2', state: 'pending' })
+  })
+
+  it('selects a declared error status and keeps its problem+json media type', async () => {
+    const res = await order('code=404')
+    expect(res.status).toBe(404)
+    expect(res.type).toBe('application/problem+json')
+    expect(problemJsonSchema.parse(JSON.parse(res.text))).toStrictEqual({
+      title: 'Order deleted',
+      status: 404,
+    })
+  })
+
+  it('combines code and a quoted example name', async () => {
+    const res = await order('code=404, example="gone"')
+    expect(res.status).toBe(404)
+  })
+
+  it('answers a response without content with an empty body', async () => {
+    const res = await order('code=503')
+    expect(res.status).toBe(503)
+    expect(res.text).toBe('')
+  })
+
+  it('falls back to the 4XX range with the requested status', async () => {
+    const res = await order('code=409')
+    expect(res.status).toBe(409)
+    expect(problemJsonSchema.safeParse(JSON.parse(res.text)).error).toBeUndefined()
+  })
+
+  it('falls back to default with the requested status', async () => {
+    const res = await order('code=502')
+    expect(res.status).toBe(502)
+    expect(problemJsonSchema.safeParse(JSON.parse(res.text)).error).toBeUndefined()
+  })
+
+  it('reads __code / __example from the query as well', async () => {
+    const byCode = await order(undefined, '?__code=503')
+    expect(byCode.status).toBe(503)
+    const res = await order(undefined, '?__example=pending')
+    expect(JSON.parse(res.text)).toStrictEqual({ id: 'o-2', state: 'pending' })
+  })
+
+  it('lets an explicit Prefer win over the 404 sentinel', async () => {
+    const res = await app.request('/orders/__non_existent__', {
+      headers: { Prefer: 'code=200' },
+    })
+    expect(res.status).toBe(200)
+  })
+
+  it.each([
+    ['example=missing', 'No example named "missing" is declared for the 200 response.'],
+    ['code=404, example=pending', 'No example named "pending" is declared for the 404 response.'],
+    ['code=abc', 'Prefer code=abc is not a status code between 200 and 599.'],
+  ])('answers 500 problem+json for the undeclared %s', async (prefer, detail) => {
+    const res = await order(prefer)
+    expect(res.status).toBe(500)
+    expect(res.type).toBe('application/problem+json')
+    expect(JSON.parse(res.text)).toMatchObject({ status: 500, detail })
+  })
+
+  it('answers 500 problem+json for a status a route without default does not declare', async () => {
+    const res = await app.request('/formats', { headers: { Prefer: 'code=500' } })
+    expect(res.status).toBe(500)
+    const body: unknown = await res.json()
+    expect(body).toMatchObject({ detail: 'No 500 response is declared for this operation.' })
+  })
+
+  it('still rejects an invalid request before honoring Prefer', async () => {
+    const res = await app.request('/users/abc', {
+      headers: { 'X-API-Key': 'key', Prefer: 'code=404' },
+    })
+    expect(res.status).toBe(400)
   })
 })

--- a/test/specs/mock-edge.yaml
+++ b/test/specs/mock-edge.yaml
@@ -1,0 +1,205 @@
+openapi: 3.1.0
+info:
+  title: Mock edge cases
+  version: 1.0.0
+  description: >-
+    Shapes the mock generator must emit valid, schema-satisfying code for:
+    non-identifier property and component names, property-name hints that
+    disagree with the declared type, OpenAPI 3.1 type arrays, config/spec
+    array-bound conflicts, maps, schema-level examples and every string format
+    the zod generator validates.
+security:
+  - ApiKeyAuth: []
+paths:
+  /users/{userId}:
+    get:
+      operationId: getUser
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: The user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User-Profile'
+        '401':
+          description: Missing API key
+        '404':
+          description: No such user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+  /formats:
+    get:
+      operationId: getFormats
+      security: []
+      responses:
+        '200':
+          description: One value per string format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Formats'
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  schemas:
+    User-Profile:
+      type: object
+      required:
+        - first-name
+        - user.name
+        - full name
+        - 1st
+        - status
+        - createdAt
+        - created_at
+        - type
+        - price
+        - nickname
+        - tags
+        - labels
+        - role
+        - bio
+        - code
+      properties:
+        first-name:
+          type: string
+        user.name:
+          type: string
+        full name:
+          type: string
+        1st:
+          type: integer
+        # Property-name hints (status/createdAt/type/price) would emit a
+        # string or a float; the declared integer type wins.
+        status:
+          type: integer
+          minimum: 100
+          maximum: 599
+        createdAt:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        type:
+          type: integer
+        price:
+          type: integer
+        nickname:
+          type: [string, 'null']
+        age:
+          type: [integer, 'null']
+        # arrayMin: 5 in the config must clamp to this maxItems.
+        tags:
+          type: array
+          maxItems: 3
+          items:
+            type: string
+        labels:
+          type: object
+          additionalProperties:
+            type: integer
+        role:
+          type: string
+          enum: [admin, member]
+          example: admin
+        bio:
+          type: string
+          examples:
+            - Hello
+        code:
+          type: string
+          pattern: '^[a-z]{3}/[0-9]{2}$'
+    Problem:
+      type: object
+      required: [title, status]
+      properties:
+        title:
+          type: string
+        status:
+          type: integer
+    Formats:
+      type: object
+      required:
+        - email
+        - uuid
+        - uuidv4
+        - uuidv7
+        - guid
+        - url
+        - httpUrl
+        - hostname
+        - ipv4
+        - ipv6
+        - cidrv4
+        - cidrv6
+        - mac
+        - date
+        - time
+        - dateTime
+        - duration
+        - ulid
+        - nanoid
+        - cuid
+        - cuid2
+        - jwt
+        - emoji
+        - hex
+        - base64
+        - base64url
+        - e164
+        - uriReference
+        - idnEmail
+        - decimal
+        - constructor
+        - toString
+        - stringInt64
+        - numberInt64
+      properties:
+        email: { type: string, format: email }
+        uuid: { type: string, format: uuid }
+        uuidv4: { type: string, format: uuidv4 }
+        uuidv7: { type: string, format: uuidv7 }
+        guid: { type: string, format: guid }
+        url: { type: string, format: url }
+        httpUrl: { type: string, format: httpUrl }
+        hostname: { type: string, format: hostname }
+        ipv4: { type: string, format: ipv4 }
+        ipv6: { type: string, format: ipv6 }
+        cidrv4: { type: string, format: cidrv4 }
+        cidrv6: { type: string, format: cidrv6 }
+        mac: { type: string, format: mac }
+        date: { type: string, format: date }
+        time: { type: string, format: time }
+        dateTime: { type: string, format: date-time }
+        duration: { type: string, format: duration }
+        ulid: { type: string, format: ulid }
+        nanoid: { type: string, format: nanoid }
+        cuid: { type: string, format: cuid }
+        cuid2: { type: string, format: cuid2 }
+        jwt: { type: string, format: jwt }
+        emoji: { type: string, format: emoji }
+        hex: { type: string, format: hex }
+        base64: { type: string, format: base64 }
+        base64url: { type: string, format: base64url }
+        e164: { type: string, format: e164 }
+        # Formats outside the zod set, and document values that name
+        # Object.prototype members, must still mock to a plain value.
+        uriReference: { type: string, format: uri-reference }
+        idnEmail: { type: string, format: idn-email }
+        decimal: { type: string, format: decimal }
+        constructor: { type: string, format: constructor }
+        toString: { type: string }
+        # A numeric format on a non-integer type is not a bigint (zod has no z.int64() here).
+        stringInt64: { type: string, format: int64 }
+        numberInt64: { type: number, format: int64 }

--- a/test/specs/mock-edge.yaml
+++ b/test/specs/mock-edge.yaml
@@ -46,7 +46,57 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Formats'
+  # Prism-compatible `Prefer: code=…, example=…` selection across every kind of
+  # declared response: named examples, problem+json, a 4XX range, default.
+  /orders/{orderId}:
+    get:
+      operationId: getOrder
+      security: []
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The order
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+              examples:
+                shipped:
+                  $ref: '#/components/examples/ShippedOrder'
+                pending:
+                  value: { id: o-2, state: pending }
+        '404':
+          description: No such order
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+              examples:
+                gone:
+                  value: { title: Order deleted, status: 404 }
+        '4XX':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '503':
+          description: Maintenance
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
 components:
+  examples:
+    ShippedOrder:
+      value: { id: o-1, state: shipped }
   securitySchemes:
     ApiKeyAuth:
       type: apiKey
@@ -120,6 +170,15 @@ components:
         code:
           type: string
           pattern: '^[a-z]{3}/[0-9]{2}$'
+    Order:
+      type: object
+      required: [id, state]
+      properties:
+        id:
+          type: string
+        state:
+          type: string
+          enum: [pending, shipped]
     Problem:
       type: object
       required: [title, status]


### PR DESCRIPTION
<!--
Title: `type(scope): summary` — imperative mood, no trailing period. Write it for the
person reading the release notes, not for the diff.

  type   feat | fix | perf | refactor | docs | test | build | ci | chore
  scope  a generator (zod, routes, app, mock, test, docs, client, …) | openapi | cli | config
         | vite-plugin | website | test | docs | ci

  fix(zod): keep `.nullable()` on a `$ref` to a nullable component schema
  feat(cli): print the files a run wrote
-->

## Why

<!-- The bug, the missing capability or the request behind this change. Link the issue: `Closes #123`. -->

## What

<!-- What changed, as someone running the CLI or reading the generated code sees it. One to three sentences. -->

## Where

<!-- Scope: which generator (routes, Zod schemas, mock, test, docs, client hooks), the OpenAPI parser, the CLI, the config, the Vite plugin, the website. Name what is deliberately left out. -->

## Who

<!-- Who notices: every user, users of one generator or one client library, contributors only. Breaking for anyone? -->

## When

<!-- Release impact: `none` | `next release` | `version bumped to x.y.z`. -->

## How

<!--
The approach in a sentence, then the evidence. For a generator change, the spec and the
output it now writes — `test/__generated__` is not committed, so paste the lines that changed
or add a case under `test/cases`; for a website change, a screenshot of the page. Tick only
what you ran; paste the output of anything that failed.
-->

- [x] `pnpm check`
- [x] `pnpm test`
- [x] `pnpm --filter ./test typecheck`, when generated output changed
- [x] `pnpm --filter ./website test:e2e`, when the website changed
