### PR TITLE
refactor(openapi): narrow parseOpenAPI input and drop unused exports

### DIFF
--- a/packages/hono-takibi/src/openapi/index.test.ts
+++ b/packages/hono-takibi/src/openapi/index.test.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test'
@@ -7,57 +8,63 @@ import { runGenerator, runGeneratorError } from '../testing/index.js'
 import { parseOpenAPI } from './index.js'
 
 describe('parseOpenAPI', () => {
-  it.concurrent('should return ok for a valid OpenAPI YAML string', async () => {
-    await expect(
-      runGenerator(
-        parseOpenAPI({
-          openapi: '3.0.0',
-          info: {
-            title: 'Test API',
-            version: '1.0.0',
-          },
-          components: {
-            schemas: {
-              Test: {
-                type: 'object',
-                required: ['test'],
-                properties: {
-                  test: {
-                    type: 'string',
-                  },
+  it.concurrent('should return ok for a valid OpenAPI JSON file', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'takibi-openapi-'))
+    const input = `${directory}/openapi.json` as const
+    fs.writeFileSync(
+      input,
+      JSON.stringify({
+        openapi: '3.0.0',
+        info: {
+          title: 'Test API',
+          version: '1.0.0',
+        },
+        components: {
+          schemas: {
+            Test: {
+              type: 'object',
+              required: ['test'],
+              properties: {
+                test: {
+                  type: 'string',
                 },
               },
             },
           },
-          paths: {
-            '/test': {
-              post: {
-                summary: 'Test endpoint',
-                requestBody: {
-                  required: true,
-                  content: {
-                    'application/json': {
-                      schema: {
-                        $ref: '#/components/schemas/Test',
-                      },
+        },
+        paths: {
+          '/test': {
+            post: {
+              summary: 'Test endpoint',
+              requestBody: {
+                required: true,
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: '#/components/schemas/Test',
                     },
                   },
                 },
-                responses: {
-                  '200': {
-                    description: 'Successful test',
-                  },
+              },
+              responses: {
+                '200': {
+                  description: 'Successful test',
                 },
               },
             },
           },
-        } as unknown as string),
-      ),
-    ).resolves.toBeDefined()
+        },
+      }),
+    )
+    try {
+      await expect(runGenerator(parseOpenAPI(input))).resolves.toBeDefined()
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true })
+    }
   })
 
-  it.concurrent('should return err for a completely invalid input', async () => {
-    const result = await runGeneratorError(parseOpenAPI('not yaml nor json'))
+  it.concurrent('should return err for a document that does not exist', async () => {
+    const result = await runGeneratorError(parseOpenAPI('not-yaml-nor-json.yaml'))
     expect(typeof result.message).toBe('string')
   })
 })
@@ -65,7 +72,7 @@ describe('parseOpenAPI', () => {
 // TypeSpec test
 // Files are created in the package root to resolve TypeSpec libraries from node_modules
 const TSP_TEST_DIR = path.resolve(import.meta.dirname, '../..')
-const TSP_TEST_FILE = `${TSP_TEST_DIR}/tmp-spec.tsp`
+const TSP_TEST_FILE = `${TSP_TEST_DIR}/tmp-spec.tsp` as const
 const TSP_TEST_SUBDIR = `${TSP_TEST_DIR}/tmp`
 
 describe('parseOpenAPI TypeSpec', () => {

--- a/packages/hono-takibi/src/openapi/index.ts
+++ b/packages/hono-takibi/src/openapi/index.ts
@@ -12,42 +12,29 @@ import { compile, NodeHost } from '@typespec/compiler'
 import { getOpenAPI3 } from '@typespec/openapi3'
 import { Data, Effect } from 'effect'
 
-/** The document could not be read, compiled or parsed into an OpenAPI object. */
-export class OpenAPIError extends Data.TaggedError('OpenAPIError')<{
+class OpenAPIError extends Data.TaggedError('OpenAPIError')<{
   readonly message: string
 }> {}
 
-/** Parses `input` into an OpenAPI document. */
-export function parseOpenAPI(input: string) {
+export function parseOpenAPI(input: `${string}.yaml` | `${string}.json` | `${string}.tsp`) {
   return Effect.tryPromise({
-    try: () => readOpenAPI(input),
+    try: async () => {
+      if (!input.endsWith('.tsp')) return (await SwaggerParser.bundle(input)) as OpenAPI
+      const program = await compile(NodeHost, path.resolve(input), { noEmit: true })
+      if (program.diagnostics.length > 0) {
+        throw new Error(
+          `TypeSpec compile failed:\n${program.diagnostics.map((d) => d.message).join('\n')}`,
+        )
+      }
+      const [record] = await getOpenAPI3(program)
+      const document =
+        record && ('document' in record ? record.document : record.versions[0]?.document)
+      if (!document) throw new Error(`TypeSpec emitted no OpenAPI document: ${input}`)
+      return document as OpenAPI
+    },
     catch: (error) =>
       new OpenAPIError({ message: error instanceof Error ? error.message : String(error) }),
   })
-}
-
-async function readOpenAPI(input: string): Promise<OpenAPI> {
-  {
-    if (typeof input === 'string' && input.endsWith('.tsp')) {
-      const program = await compile(NodeHost, path.resolve(input), {
-        noEmit: true,
-      })
-      if (program.diagnostics.length > 0) {
-        // Extract error messages from diagnostics (avoid circular reference in JSON.stringify)
-        const errors = program.diagnostics.map((d) => d.message).join('\n')
-        throw new Error(`TypeSpec compile failed:\n${errors}`)
-      }
-      const [record] = await getOpenAPI3(program)
-      // The emitter returns a self-contained document (every `$ref` is `#/...`),
-      // so there is nothing for `bundle()` to resolve here.
-      const tsp = 'document' in record ? record.document : record.versions[0].document
-      return tsp as OpenAPI
-    }
-    // `Awaited<ReturnType<typeof SwaggerParser.parse>>` therefore cannot be narrowed to our `OpenAPI` type.
-    // The parser validates the spec at runtime but does not express this guarantee in its type definition,
-    // so we assert `OpenAPI` here to enable typed access in the generator.
-    return (await SwaggerParser.bundle(input)) as OpenAPI
-  }
 }
 
 export type OpenAPI = {
@@ -185,7 +172,7 @@ export type Type =
 
 export type Format = FormatString | FormatNumber
 
-export type FormatString =
+type FormatString =
   | 'email'
   | 'uuid'
   | 'uuidv4'
@@ -224,7 +211,7 @@ export type FormatString =
   | 'toUpperCase' /* toUpperCase */
   | 'trim' /* trim whitespace */
 
-export type FormatNumber =
+type FormatNumber =
   | 'int32'
   | 'int64'
   | 'bigint'
@@ -234,7 +221,7 @@ export type FormatNumber =
   | 'double'
   | 'password'
 
-export type Ref =
+type Ref =
   | `#/components/schemas/${string}`
   | `#/components/responses/${string}`
   | `#/components/parameters/${string}`

--- a/packages/hono-takibi/src/vite-plugin/index.test.ts
+++ b/packages/hono-takibi/src/vite-plugin/index.test.ts
@@ -8,7 +8,7 @@ import { Effect } from 'effect'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
 import * as FormatModule from '../format/index.js'
-import * as OpenAPIModule from '../openapi/index.js'
+import type * as OpenAPIModule from '../openapi/index.js'
 import { honoTakibiVite } from './index.js'
 
 type ViteDevServer = {
@@ -157,21 +157,17 @@ vi.mock('../core/index.js', () => ({
   webhooks: vi.fn<() => Effect.Effect<string>>(() => Effect.succeed('webhooks')),
 }))
 
-vi.mock('../openapi/index.js', async () => {
-  const actual = await vi.importActual<typeof OpenAPIModule>('../openapi/index.js')
-  return {
-    OpenAPIError: actual.OpenAPIError,
-    parseOpenAPI: vi.fn<() => Effect.Effect<unknown>>(() =>
-      Effect.succeed({
-        paths: {
-          '/pets': { get: { responses: {} } },
-          '/users': { post: { responses: {} } },
-        },
-        components: { schemas: { Pet: {}, User: {} } },
-      }),
-    ),
-  }
-})
+vi.mock('../openapi/index.js', () => ({
+  parseOpenAPI: vi.fn<() => Effect.Effect<unknown>>(() =>
+    Effect.succeed({
+      paths: {
+        '/pets': { get: { responses: {} } },
+        '/users': { post: { responses: {} } },
+      },
+      components: { schemas: { Pet: {}, User: {} } },
+    }),
+  ),
+}))
 
 vi.mock('../format/index.js', async () => {
   const actual = await vi.importActual<typeof FormatModule>('../format/index.js')
@@ -663,9 +659,12 @@ describe('honoTakibiVite', () => {
 
   it('logs error and does not send full-reload when parseOpenAPI fails', async () => {
     const { parseOpenAPI } = await import('../openapi/index.js')
-    vi.mocked(parseOpenAPI).mockImplementationOnce(() =>
-      Effect.fail(new OpenAPIModule.OpenAPIError({ message: 'parse failure' })),
+    // `OpenAPIError` is module-private, so take a real one from the unmocked parser.
+    const actual = await vi.importActual<typeof OpenAPIModule>('../openapi/index.js')
+    const failure = await Effect.runPromise(
+      Effect.flip(actual.parseOpenAPI(`${testState.sandboxDirectory}/missing.yaml`)),
     )
+    vi.mocked(parseOpenAPI).mockImplementationOnce(() => Effect.fail(failure))
 
     const configuration = {
       input: 'openapi.yaml',
@@ -681,7 +680,7 @@ describe('honoTakibiVite', () => {
     const plugin = honoTakibiVite()
     plugin.configureServer(server)
     await waitFor(() => {
-      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('❌ parseOpenAPI: parse failure'))
+      expect(logSpy).toHaveBeenCalledWith(`❌ parseOpenAPI: ${failure.message}`)
     })
     await new Promise((resolve) => setTimeout(resolve, 50))
 


### PR DESCRIPTION
- parseOpenAPI accepts only `.yaml` / `.json` / `.tsp` paths and inlines the reader
- guard against TypeSpec emitting no document instead of indexing blindly
- make OpenAPIError, FormatString, FormatNumber and Ref module-private
- tests: pass real file paths, and take a real OpenAPIError from the unmocked parser

<!--
Title: `type(scope): summary` — imperative mood, no trailing period. Write it for the
person reading the release notes, not for the diff.

  type   feat | fix | perf | refactor | docs | test | build | ci | chore
  scope  a generator (zod, routes, app, mock, test, docs, client, …) | openapi | cli | config
         | vite-plugin | website | test | docs | ci

  fix(zod): keep `.nullable()` on a `$ref` to a nullable component schema
  feat(cli): print the files a run wrote
-->

## Why

<!-- The bug, the missing capability or the request behind this change. Link the issue: `Closes #123`. -->

## What

<!-- What changed, as someone running the CLI or reading the generated code sees it. One to three sentences. -->

## Where

<!-- Scope: which generator (routes, Zod schemas, mock, test, docs, client hooks), the OpenAPI parser, the CLI, the config, the Vite plugin, the website. Name what is deliberately left out. -->

## Who

<!-- Who notices: every user, users of one generator or one client library, contributors only. Breaking for anyone? -->

## When

<!-- Release impact: `none` | `next release` | `version bumped to x.y.z`. -->

## How

<!--
The approach in a sentence, then the evidence. For a generator change, the spec and the
output it now writes — `test/__generated__` is not committed, so paste the lines that changed
or add a case under `test/cases`; for a website change, a screenshot of the page. Tick only
what you ran; paste the output of anything that failed.
-->

- [x] `pnpm check`
- [x] `pnpm test`
- [x] `pnpm --filter ./test typecheck`, when generated output changed
- [x] `pnpm --filter ./website test:e2e`, when the website changed
